### PR TITLE
code readability improvements (remove acronyms)

### DIFF
--- a/Modules/PointManager/DKP/LedgerEntries.lua
+++ b/Modules/PointManager/DKP/LedgerEntries.lua
@@ -138,5 +138,6 @@ end
 MODELS.LEDGER.DKP = {
     Modify = Modify,
     Set = Set,
-    Decay = Decay
+    Decay = Decay,
+    ModifyRaid = ModifyRaid
 }


### PR DESCRIPTION
Minor refactoring to remove some unneeded acronyms from the code.

I'll make more of this so we can increase code readability for people who did not write it ;-)