### PR TITLE
Add esES support

### DIFF
--- a/ClassicLootManager.toc
+++ b/ClassicLootManager.toc
@@ -53,6 +53,7 @@ Locale\enUS.lua
 Locale\ruRU.lua
 Locale\frFR.lua
 #Locale\itIT.lua
+Locale\esES.lua
 
 # Addon Core
 ClassicLootManager.lua

--- a/Locale/esES.lua
+++ b/Locale/esES.lua
@@ -1,0 +1,1680 @@
+local _, CLM = ...
+if GetLocale() == "esES" then
+-- Modules/BiddingManager/GUI.lua:424
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:47
+CLM.L[" DKP "] = " DKP "
+-- Modules/LedgerManager/GUI.lua:500
+CLM.L[" Sandbox"] = " Sandbox "
+-- Modules/LedgerManager/GUI.lua:271
+-- Modules/LedgerManager/GUI.lua:284
+CLM.L[" Too much data to display"] = " Demasiados datos para mostrar "
+-- Modules/LedgerManager/GUI.lua:303
+CLM.L[" UNUSED"] = " NO USADO"
+-- Modules/LedgerManager/GUI.lua:243
+CLM.L[" alt of: "] = " ater de "
+-- Modules/PointManager/GUI.lua:169
+CLM.L[" more"] = " más "
+-- Modules/RosterManager/GUI.lua:119
+CLM.L[" players in roster"] = " jugadores en roster  "
+-- Modules/LedgerManager/GUI.lua:309
+CLM.L[" profile(s)"] = " perfil(es)"
+-- Global/GlobalChatMessageHandlers.lua:40
+CLM.L["!bid"] = "!bid"
+-- Global/GlobalChatMessageHandlers.lua:67
+CLM.L["!dkp"] = "!dkp"
+-- Modules/RaidManager/GUI.lua:511
+-- Modules/PointManager/GUI.lua:274
+-- Modules/AuctionHistoryManager/GUI.lua:226
+-- Modules/LootManager/GUI.lua:317
+CLM.L["%Y/%m/%d %a %H:%M:%S"] = "%Y/%m/%d %a %H:%M:%S"
+-- Alerts/Alerts.lua:16
+CLM.L["%d %% DKP decay"] = "%d %% Decalage DKP"
+-- Alerts/Alerts.lua:14
+CLM.L["%d DKP"] = "%d DKP"
+-- Modules/LedgerManager/GUI.lua:447
+CLM.L["%d/%m/%Y %H:%M:%S"] = "%d/%m/%Y %H:%M:%S"
+-- Modules/LootManager/LootManager.lua:156
+CLM.L["%s awarded to %s for %s DKP"] = "%s adjudicado a %s por %s DKP"
+-- MinimapIcon.lua:123
+CLM.L["%s events (%s pending)"] = "%s eventos (%s pendientes)"
+-- MinimapIcon.lua:125
+CLM.L["%s events (0x%x)"] = "%s eventos (0x%x)"
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:54
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:84
+CLM.L["%s has %s standby"] = "%s tiene %s en espera"
+-- Global/GlobalSlashCommands.lua:210
+CLM.L["%s is not part of the %s roster"] = "%s no es parte del  %s roster"
+-- Global/GlobalSlashCommands.lua:131
+CLM.L["%s profile exists."] = "%s perfil existente."
+-- Global/GlobalSlashCommands.lua:133
+CLM.L["%s profile missing. Adding."] = "%s falta el perfil. Agregando."
+-- Modules/LedgerManager/GUI.lua:387
+-- Modules/LedgerManager/GUI.lua:397
+CLM.L["%s to %s for %s in <%s>"] = "%s a %s para %s en <%s>"
+-- Global/GlobalSlashCommands.lua:139
+CLM.L["%s was not found in guild."] = "%s no se encontró en la Hermandad."
+-- Modules/PointManager/GUI.lua:322
+-- Modules/PointManager/GUI.lua:322
+-- Modules/PointManager/GUI.lua:323
+CLM.L["-- History --"] = "-- Histórico --"
+-- Modules/LootManager/GUI.lua:364
+-- Modules/LootManager/GUI.lua:364
+-- Modules/LootManager/GUI.lua:365
+CLM.L["-- Raid Loot --"] = "-- Botín de Raid --"
+-- Global/GlobalChatMessageHandlers.lua:100
+CLM.L["<CLM> %s not present in any roster."] = "<CLM> %s no está presente en ningun roster."
+-- Global/GlobalChatMessageHandlers.lua:102
+CLM.L["<CLM> %s standings in %d %s:"] = "<CLM> %s posiciones en %d %s:"
+-- Global/GlobalChatMessageHandlers.lua:111
+CLM.L["<CLM> %s: %d DKP (%d this week)."] = "<CLM> %s: %d DKP (%d esta semana)."
+-- Global/GlobalChatMessageHandlers.lua:81
+CLM.L["<CLM> Missing profile for player %s."] = "<CLM> Falta el perfil del jugador %s."
+-- Global/GlobalChatMessageHandlers.lua:61
+CLM.L["<CLM> Your bid (%s) was %s%s."] = "<CLM> Tu oferta (%s) es %s%s."
+-- Modules/ProfileManager/GUI.lua:205
+CLM.L["Add currently selected target to list."] = "Agregar objetivo seleccionado actualmente a la lista."
+-- Modules/ProfileManager/GUI.lua:204
+CLM.L["Add target"] = "Agregar objetivo"
+-- Modules/ProfileManager/GUI.lua:288
+CLM.L["Add to roster"] = "Agregar al Roster"
+-- Modules/RosterManager/GUI.lua:512
+CLM.L["Add to standby"] = "Añadir en espera"
+-- Modules/LedgerManager/GUI.lua:309
+CLM.L["Add"] = "Añadir"
+-- Migration.lua:349
+CLM.L["Adding %s loot entries for team to %s"] = "Agregando %s entradas de botín para el equipo a %s"
+-- Migration.lua:208
+-- Migration.lua:327
+CLM.L["Adding %s profiles to %s"] = "Agregando %s perfiles a %s"
+-- Modules/RosterManager/RosterManager.lua:596
+CLM.L["Adding missing %s players to current roster"] = "Agregar %s jugadores faltantes al roster actual"
+-- Modules/RosterManager/Options.lua:785
+CLM.L["Additional cost (tax) to add to the award value."] = "Coste adicional (tasa) para agregar al valor del premio."
+-- Modules/RosterManager/Options.lua:755
+CLM.L["Additional points to be given to players atop of the split value."] = "Se otorgarán puntos adicionales a los jugadores además del valor compartido."
+-- Modules/ProfileManager/GUI.lua:289
+CLM.L["Adds selected players or everyone if none selected to the selected roster (from dropdown)."] = "Agrega jugadores seleccionados o todos si ninguno está seleccionado a la lista seleccionada (del menú desplegable)."
+-- Modules/PointManager/GUI.lua:139
+CLM.L["Affected players:"] = "Jugadores afectados: "
+-- Modules/AutoAwardManager/EncounterIDs.lua:100
+CLM.L["Akil'zon"] = "Akil'zon"
+-- Modules/AutoAwardManager/EncounterIDs.lua:82
+CLM.L["Al'ar"] = "Al'ar"
+-- Modules/BiddingManager/GUI.lua:76
+CLM.L["All In"] = "Todo incluido"
+-- Modules/BiddingManager/GUI.lua:48
+CLM.L["All in"] = "All in"
+-- Migration.lua:28
+CLM.L["All migration entries were commited and executed. Congratulations!"] = "Todas las entradas de migración se confirmaron y ejecutaron. ¡Felicidades!"
+-- Modules/RosterManager/GUI.lua:191
+-- Modules/ProfileManager/GUI.lua:110
+CLM.L["All"] = "Todo"
+-- Modules/RosterManager/Options.lua:769
+CLM.L["Allow Negative Bidders"] = "Autoriser les enchéres négatifs"
+-- Modules/RosterManager/Options.lua:762
+CLM.L["Allow Negative Standings"] = "Permitir pujas negativas"
+-- Modules/LedgerManager/GUI.lua:116
+CLM.L["Allow bidding below 0 DKP"] = "Permitir pujar por debajo de 0 DKP"
+-- Modules/RosterManager/Options.lua:763
+CLM.L["Allow biding more than current standings and end up with negative values."] = "Permitir ofertas por encima del rango actual y obtener valores negativos."
+-- Modules/RosterManager/Options.lua:770
+CLM.L["Allow biding when current standings are negative values."] = "Permitir ofertar cuando las clasificaciones actuales son valores negativos."
+-- Modules/LedgerManager/GUI.lua:113
+CLM.L["Allow going below 0  DKP"] = "Permite ir por debajo de 0 DKP"
+-- Modules/RaidManager/GUI.lua:306
+-- Modules/RosterManager/Options.lua:712
+CLM.L["Allow players to subscribe to the bench through Raids menu"] = "Permitir que los jugadores se suscriban al banquillo a través del menú Raids"
+-- Modules/RaidManager/GUI.lua:305
+-- Modules/RosterManager/Options.lua:711
+-- Modules/LedgerManager/GUI.lua:173
+CLM.L["Allow subscription"] = "Permitir suscripción"
+-- Modules/RosterManager/Roster.lua:815
+CLM.L["Americas"] = "Américas"
+-- Modules/RosterManager/Roster.lua:765
+-- Modules/RosterManager/Roster.lua:797
+CLM.L["Ammo"] = "Munición"
+-- Modules/AutoAwardManager/EncounterIDs.lua:96
+CLM.L["Anetheron"] = "Anetheron"
+-- Modules/AuctionManager/AuctionManager.lua:80
+CLM.L["Announce award to Guild"] = "Anunciar el premio a la Hermandad"
+-- Global/GlobalConfigs.lua:77
+CLM.L["Announce loot from corpse to Raid"] = "Anunciar el botín a la raid"
+-- Global/GlobalConfigs.lua:73
+CLM.L["Announce loot"] = "Anunciar el botín"
+-- Global/GlobalConfigs.lua:95
+CLM.L["Announcement loot rarity"] = "Anuncio de rareza de botín"
+-- Modules/RosterManager/Roster.lua:679
+CLM.L["Anonymous Open"] = "Anónimo abierto"
+-- Modules/RosterManager/Options.lua:800
+CLM.L["Anti-snipe time"] = "Tiempo anti-snipe"
+-- Modules/AuctionManager/AuctionManager.lua:244
+CLM.L["Anti-snipe time: %s."] = "Tiempo anti-snipe: %s."
+-- Modules/RaidManager/GUI.lua:201
+-- Modules/AuctionManager/GUI.lua:423
+-- Modules/LedgerManager/GUI.lua:110
+CLM.L["Anti-snipe"] = "Anti-snipe"
+-- Modules/AutoAwardManager/EncounterIDs.lua:31
+CLM.L["Anub'Rekhan"] = "Anub'Rekhan"
+-- Modules/ProfileManager/GUI.lua:148
+CLM.L["Any"] = "Todo"
+-- Modules/LedgerManager/GUI.lua:485
+CLM.L["Applies all changes and exits sandbox mode"] = "Aplica todos los cambios y salir del modo sandbox"
+-- Modules/LedgerManager/GUI.lua:484
+CLM.L["Apply changes"] = "Aplicar los cambios"
+-- Modules/AutoAwardManager/EncounterIDs.lua:99
+CLM.L["Archimonde"] = "Archimonde"
+-- Modules/AuctionManager/GUI.lua:487
+CLM.L["Are you sure, you want to award %s to %s for %s DKP?"] = "¿Está seguro de que desea otorgar %s a %s por %s DKP?"
+-- Modules/RosterManager/Roster.lua:699
+CLM.L["Ascending"] = "Ascendente"
+-- Modules/ProfileManager/GUI.lua:444
+CLM.L["Assistant"] = "Asistente"
+-- Modules/RosterManager/GUI.lua:486
+CLM.L["Attendance [%]"] = "Asistencia [%]"
+-- Modules/RosterManager/RosterManager.lua:266
+CLM.L["Attendance"] = "Asistencia"
+-- Modules/AutoAwardManager/EncounterIDs.lua:62
+CLM.L["Attumen the Huntsman"] = "Attumen el Montero"
+-- Global/GlobalConfigs.lua:144
+CLM.L["Auction End Countdown"] = "Cuenta regresiva para el final de la subasta"
+-- MinimapIcon.lua:51
+-- Modules/AuctionHistoryManager/GUI.lua:195
+CLM.L["Auction History"] = "Historial de subastas"
+-- Modules/AuctionManager/GUI.lua:447
+CLM.L["Auction Results"] = "Resultados de la subasta"
+-- Global/GlobalConfigs.lua:126
+CLM.L["Auction Start/End"] = "Subasta Inicio/Terminación"
+-- Modules/RaidManager/GUI.lua:200
+-- Modules/LedgerManager/GUI.lua:107
+CLM.L["Auction Time"] = "Tiempo de subasta"
+-- Modules/LedgerManager/GUI.lua:95
+CLM.L["Auction Type"] = "Tipo de subasta"
+-- Modules/AuctionManager/AuctionManager.lua:312
+CLM.L["Auction complete"] = "Subasta completa"
+-- Modules/BiddingManager/BiddingManager.lua:219
+CLM.L["Auction finished"] = "Subasta finalizada"
+-- Modules/LootQueueManager/GUI.lua:60
+CLM.L["Auction item"] = "Artículo de subasta"
+-- Modules/RosterManager/Options.lua:793
+CLM.L["Auction length in seconds."] = "Duración de la subasta en segundos."
+-- Modules/AuctionManager/GUI.lua:413
+-- Modules/RosterManager/Options.lua:792
+CLM.L["Auction length"] = "Duración de la subasta."
+-- Modules/BiddingManager/BiddingManager.lua:206
+CLM.L["Auction of "] = "Subasta de"
+-- Modules/AuctionManager/AuctionManager.lua:229
+CLM.L["Auction of %s"] = "Subasta de %s"
+-- Modules/RosterManager/Options.lua:727
+CLM.L["Auction settings"] = "Configuración de la subasta"
+-- Modules/AuctionManager/AuctionManager.lua:323
+CLM.L["Auction stopped by Master Looter"] = "Subasta detenida por el Master Looter"
+-- Modules/AuctionManager/AuctionManager.lua:242
+CLM.L["Auction time: %s."] = "Tiempo de subasta: %s."
+-- Modules/RosterManager/Options.lua:731
+CLM.L["Auction type"] = "Tipo de subasta"
+-- Modules/AuctionManager/AuctionManager.lua:108
+CLM.L["Auctioning - Chat Commands"] = "Subastas: comandos de chat"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:61
+CLM.L["Auctioning - History"] = "Subastas - Historia"
+-- MinimapIcon.lua:46
+-- Modules/AuctionManager/GUI.lua:587
+-- Modules/AuctionManager/AuctionManager.lua:76
+CLM.L["Auctioning"] = "Subasta"
+-- MinimapIcon.lua:74
+CLM.L["Audit"] = "Auditoría"
+-- Modules/LedgerManager/GUI.lua:56
+CLM.L["Author"] = "Autor"
+-- Modules/RaidManager/GUI.lua:297
+-- Modules/RosterManager/Options.lua:719
+-- Modules/LedgerManager/GUI.lua:161
+CLM.L["Auto bench leavers"] = "Bancos automáticos"
+-- Modules/AuctionManager/AuctionManager.lua:89
+CLM.L["Auto-award from corpse"] = "Recompensa automática del cadáver"
+-- Modules/AuctionManager/AuctionManager.lua:98
+CLM.L["Auto-trade after award"] = "Intercambio automático después de la adjudicación"
+-- Modules/RosterManager/RosterManager.lua:288
+CLM.L["Average weeks"] = "Semanas promedio"
+-- Modules/RosterManager/GUI.lua:263
+CLM.L["Award DKP to selected players or everyone if none selected."] = "Otorgue DKP a los jugadores seleccionados o a todos si no se seleccionó ninguno."
+-- Modules/RosterManager/GUI.lua:229
+CLM.L["Award DKP value"] = "Asignar valor DKP"
+-- Global/GlobalSlashCommands.lua:26
+CLM.L["Award item without auctioning it."] = "Adjudicar artículo sin subastarlo."
+-- Modules/AuctionManager/GUI.lua:452
+-- Global/GlobalSlashCommands.lua:25
+CLM.L["Award item"] = "Asignar objeto"
+-- Modules/RosterManager/Options.lua:655
+CLM.L["Award points only to online players"] = "Otorga puntos solo a jugadores en línea"
+-- Modules/RosterManager/Options.lua:664
+CLM.L["Award points only to players in same zone"] = "Otorga puntos solo a jugadores en la misma zona"
+-- Modules/AuctionManager/GUI.lua:458
+CLM.L["Award value"] = "Valor asignado"
+-- Modules/AuctionManager/GUI.lua:467
+-- Modules/RosterManager/GUI.lua:262
+CLM.L["Award"] = "Recompensa"
+-- Modules/LedgerManager/GUI.lua:360
+CLM.L["Awarded %s DKP for %s to all players in raid %s"] = "Otorgó %s DKP por %s a todos los jugadores en la raid %s"
+-- Modules/LedgerManager/GUI.lua:336
+CLM.L["Awarded %s DKP to %s players for %s in <%s>"] = "Otorgó %s DKP a %s jugadores por %s en <%s>"
+-- Modules/LedgerManager/GUI.lua:352
+CLM.L["Awarded %s DKP to all players for %s in <%s>"] = "Otorgó %s DKP a todos los jugadores por %s en <%s>"
+-- Modules/PointManager/GUI.lua:97
+-- Modules/LootManager/GUI.lua:187
+CLM.L["Awarded by"] = "Otorgado por"
+-- Modules/AuctionManager/GUI.lua:261
+-- Modules/AuctionManager/GUI.lua:659
+CLM.L["Awarding to %s for %d."] = "Otorgando a %s por %d."
+-- Modules/AutoAwardManager/EncounterIDs.lua:60
+CLM.L["Ayamiss the Hunter"] = "Ayamiss el Cazador"
+-- Modules/AutoAwardManager/EncounterIDs.lua:98
+CLM.L["Azgalor"] = "Azgalor"
+-- Modules/RosterManager/Roster.lua:744
+-- Modules/RosterManager/Roster.lua:776
+CLM.L["Back"] = "Atras"
+-- Modules/RosterManager/Roster.lua:764
+-- Modules/RosterManager/Roster.lua:796
+CLM.L["Bag"] = "Bolsa"
+-- Modules/AutoAwardManager/EncounterIDs.lua:8
+CLM.L["Baron Geddon"] = "Baron Geddon"
+-- Modules/RosterManager/Options.lua:318
+CLM.L["Base value for Static-Priced auction. Minimum value for Ascending auction. Set to 0 to ignore."] = "Valor base para subasta de precio estático. Valor mínimo para subasta Ascendente. Establecer en 0 para ignorar."
+-- Modules/BiddingManager/GUI.lua:262
+-- Modules/AuctionManager/GUI.lua:381
+-- Modules/RosterManager/Options.lua:373
+CLM.L["Base"] = "Base"
+-- Modules/BiddingManager/GUI.lua:433
+CLM.L["Base: %d "] = "Base: %d "
+-- Modules/AutoAwardManager/EncounterIDs.lua:24
+CLM.L["Battleguard Sartura"] = "Guardia de batalla Sartura"
+-- Modules/RosterManager/Options.lua:705
+CLM.L["Bench"] = "Banquillo"
+-- Alerts/Alerts.lua:24
+CLM.L["Bid %s accepted!"] = "¡Oferta %s aceptada!"
+-- Alerts/Alerts.lua:30
+CLM.L["Bid %s denied!"] = "¡Oferta %s rechazada!"
+-- Modules/AuctionManager/AuctionManager.lua:667
+CLM.L["Bid cancelling not allowed"] = "Cancelación de oferta no permitida"
+-- Modules/AuctionManager/AuctionManager.lua:665
+CLM.L["Bid increment too low"] = "Incremento de oferta demasiado bajo"
+-- Modules/BiddingManager/GUI.lua:255
+CLM.L["Bid input value."] = "Valor de entrada de oferta."
+-- Modules/AuctionManager/AuctionManager.lua:663
+CLM.L["Bid too high"] = "Oferta demasiado alta"
+-- Modules/AuctionManager/AuctionManager.lua:662
+CLM.L["Bid too low"] = "Oferta demasiado baja"
+-- Modules/BiddingManager/GUI.lua:245
+CLM.L["Bid value"] = "Valor de la oferta"
+-- Modules/BiddingManager/GUI.lua:77
+CLM.L["Bid your current DKP (%s)."] = "Oferte su DKP actual (%s)."
+-- Modules/BiddingManager/GUI.lua:95
+CLM.L["Bid your preset value."] = "Oferte su valor preestablecido."
+-- Modules/BiddingManager/GUI.lua:254
+-- Modules/AuctionManager/GUI.lua:236
+CLM.L["Bid"] = "Oferta de compra"
+-- Modules/AuctionManager/AuctionManager.lua:661
+CLM.L["Bidding over current standings not allowed"] = "No se permite pujar sobre la clasificación actual"
+-- MinimapIcon.lua:61
+-- Modules/BiddingManager/BiddingManager.lua:61
+-- Modules/BiddingManager/GUI.lua:328
+-- Modules/BiddingManager/GUI.lua:502
+CLM.L["Bidding"] = "Ofertas"
+-- Modules/AuctionHistoryManager/GUI.lua:141
+-- Modules/LootManager/GUI.lua:190
+-- Global/GlobalConfigs.lua:162
+CLM.L["Bids"] = "Ofertas"
+-- Modules/AutoAwardManager/EncounterIDs.lua:277
+CLM.L["Black Temple"] = "Templo Oscuro"
+-- Modules/AutoAwardManager/EncounterIDs.lua:142
+CLM.L["Blackwing Lair"] = "Guarida Alanegra"
+-- Modules/AutoAwardManager/EncounterIDs.lua:51
+CLM.L["Bloodlord Mandokir"] = "Señor sangriento Mandokir"
+-- Modules/RosterManager/Options.lua:571
+CLM.L["Bonuses"] = "Bonus"
+-- ClassicLootManager.lua:188
+CLM.L["Boot complete"] = "Arranque completo"
+-- Modules/RaidManager/GUI.lua:202
+-- Modules/RaidManager/GUI.lua:229
+-- Modules/RosterManager/Options.lua:577
+-- Modules/PointManager/PointManager.lua:411
+-- Modules/LedgerManager/GUI.lua:119
+CLM.L["Boss Kill Bonus"] = "Bonificación por muerte de jefe"
+-- Modules/RosterManager/Options.lua:820
+CLM.L["Boss kill award values"] = "Valores de recompensa por muerte de jefe"
+-- Modules/AutoAwardManager/EncounterIDs.lua:16
+CLM.L["Broodlord Lashlayer"] = "Señor de linaje Capazote"
+-- Modules/AutoAwardManager/EncounterIDs.lua:107
+CLM.L["Brutallus"] = "Brutallus"
+-- Modules/AutoAwardManager/EncounterIDs.lua:59
+CLM.L["Buru the Gorger"] = "Buru el Manducador"
+-- Modules/AutoAwardManager/EncounterIDs.lua:30
+CLM.L["C'Thun"] = "C'Thun"
+-- Modules/BiddingManager/GUI.lua:297
+CLM.L["Cancel your bid."] = "Cancele su oferta."
+-- Modules/BiddingManager/GUI.lua:296
+CLM.L["Cancel"] = "Cancelar"
+-- Modules/RosterManager/Options.lua:489
+CLM.L["Change roster name."] = "Cambiar el nombre del Roster."
+-- Modules/Changelog/GUI.lua:36
+-- Modules/Changelog/GUI.lua:125
+-- Modules/Changelog/GUI.lua:126
+CLM.L["Changelog"] = "Registro de cambios"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:84
+CLM.L["Channel for posting bids."] = "Canal de publicación de ofertas."
+-- Global/GlobalConfigs.lua:135
+CLM.L["Chat Commands"] = "Comandos de chat"
+-- Modules/AutoAwardManager/EncounterIDs.lua:70
+CLM.L["Chess Event"] = "Chess Event"
+-- Modules/RosterManager/Roster.lua:746
+-- Modules/RosterManager/Roster.lua:778
+CLM.L["Chest (robes)"] = "Pecho (túnicas)"
+-- Modules/RosterManager/Roster.lua:745
+-- Modules/RosterManager/Roster.lua:777
+CLM.L["Chest"] = "Pecho"
+-- Modules/AutoAwardManager/EncounterIDs.lua:20
+CLM.L["Chromaggus"] = "Chromaggus"
+-- Modules/AuctionManager/GUI.lua:228
+-- Modules/RosterManager/GUI.lua:478
+-- Modules/ProfileManager/GUI.lua:375
+CLM.L["Class"] = "Clase"
+-- Modules/ProfileInfoManager/ProfileInfoManager.lua:224
+CLM.L["Classic Loot Manager %s initialization complete."] = "Classic Loot Manager %s inicialización completa."
+-- Modules/RosterManager/Options.lua:412
+CLM.L["Classic"] = "Classic"
+-- Modules/RosterManager/GUI.lua:206
+-- Modules/ProfileManager/GUI.lua:124
+CLM.L["Clear all classes."] = "Borrar todas las clases."
+-- Modules/ProfileManager/GUI.lua:256
+CLM.L["Clear mains"] = "Borrar mains"
+-- Modules/ProfileManager/GUI.lua:257
+CLM.L["Clears selected profiles mains."] = "Borra los perfiles (mains) seleccionados."
+-- Modules/LootQueueManager/LootQueueManager.lua:83
+-- Global/GlobalConfigs.lua:101
+CLM.L["Common"] = "Común"
+-- MinimapIcon.lua:80
+-- Modules/RaidManager/GUI.lua:435
+CLM.L["Configuration"] = "Configuración"
+-- Modules/RosterManager/Options.lua:526
+-- Modules/RosterManager/Options.lua:534
+CLM.L["Copy settings from selected roster."] = "Copie la configuración del roster seleccionado."
+-- Modules/RosterManager/Options.lua:519
+-- Modules/RosterManager/Options.lua:525
+CLM.L["Copy settings"] = "Copiar parámetros"
+-- Modules/RosterManager/Options.lua:533
+CLM.L["Copy source"] = "Copiar fuente"
+-- Modules/PointManager/PointManager.lua:416
+CLM.L["Correcting error"] = "Corrección de error"
+-- Modules/RaidManager/GUI.lua:352
+CLM.L["Create new raid with provided name. You will automatically join this raid and leave any other you are part of."] = "Crea una nueva raid con el nombre proporcionado. Automáticamente te unirás a esta raod y dejarás cualquier otra de la que formes parte."
+-- Modules/LedgerManager/GUI.lua:407
+CLM.L["Create raid %s %s in <%s>"] = "Crear raid %s %s en <%s>"
+-- Modules/RaidManager/GUI.lua:351
+CLM.L["Create raid"] = "Crear raid"
+-- Modules/RaidManager/GUI.lua:314
+-- Modules/RosterManager/Options.lua:832
+CLM.L["Create"] = "Crear"
+-- Modules/RaidManager/GUI.lua:390
+-- Modules/RaidManager/RaidManager.lua:802
+CLM.L["Created"] = "Creada"
+-- Modules/RosterManager/Options.lua:833
+CLM.L["Creates new roster with default configuration"] = "Crea un nuevo roster con la configuración predeterminada"
+-- Modules/AuctionManager/GUI.lua:240
+CLM.L["Current"] = "Actual"
+-- Modules/RaidManager/GUI.lua:522
+CLM.L["Currently in raid: "] = "Actualmente en raid: "
+-- Modules/RosterManager/Options.lua:496
+-- Modules/RosterManager/Options.lua:850
+CLM.L["Currently only DKP supported."] = "Actualmente solo se admite DKP."
+-- Modules/BiddingManager/GUI.lua:153
+CLM.L["Custom button mode"] = "Modo de botón personalizado"
+-- Modules/BiddingManager/GUI.lua:49
+-- Modules/BiddingManager/GUI.lua:162
+CLM.L["Custom value"] = "Valor personalizado"
+-- Modules/RosterManager/GUI.lua:321
+CLM.L["DKP % that will be decayed."] = "DKP % que se decaerá."
+-- Global/GlobalConfigs.lua:46
+CLM.L["DKP & Loot alerts"] = "Alertas de botín y DKP"
+-- Modules/RosterManager/GUI.lua:230
+CLM.L["DKP value that will be awarded."] = "Valor DKP que se otorgará."
+-- Modules/RosterManager/Roster.lua:655
+-- Modules/RosterManager/GUI.lua:477
+-- Modules/RosterManager/GUI.lua:644
+CLM.L["DKP"] = "DKP"
+-- Modules/PointManager/GUI.lua:95
+-- Modules/LootManager/GUI.lua:95
+-- Modules/LootManager/GUI.lua:102
+CLM.L["Date"] = "Fecha"
+-- Modules/RosterManager/GUI.lua:320
+CLM.L["Decay DKP %"] = "Decaimiento DKP%"
+-- Modules/RosterManager/GUI.lua:339
+-- Modules/PointManager/PointManager.lua:422
+CLM.L["Decay"] = "Decaimiento"
+-- Modules/LedgerManager/GUI.lua:344
+CLM.L["Decayed %s%% DKP to %s players in <%s>"] = "%s%% DKP restado a %s jugadores en <%s>"
+-- Modules/LedgerManager/GUI.lua:368
+CLM.L["Decayed %s%% DKP to all players %sin <%s>"] = "Restó %s%% DKP a todos los jugadores %sin <%s>"
+-- Modules/RosterManager/Options.lua:584
+CLM.L["Default Boss Kill Bonus Value"] = "Valor de bonificación por muerte de jefe predeterminado"
+-- Modules/LedgerManager/GUI.lua:122
+CLM.L["Default Boss Kill Bonus value"] = "Valor predeterminado de la bonificación Boss Muerto"
+-- Modules/RosterManager/Options.lua:810
+CLM.L["Default slot values"] = "Valores de slot predeterminados"
+-- Modules/LedgerManager/GUI.lua:55
+CLM.L["Description"] = "Descripción"
+-- Modules/BiddingManager/GUI.lua:47
+CLM.L["Disabled"] = "Desactivado"
+-- Modules/Changelog/GUI.lua:41
+CLM.L["Disables display of the changelog for any new version."] = "Deshabilita la visualización del registro de cambios para cualquier versión nueva."
+-- Modules/LedgerManager/GUI.lua:492
+CLM.L["Discard changes"] = "Descartar los cambios"
+-- Modules/LedgerManager/GUI.lua:493
+CLM.L["Discards all changes and exits sandbox mode"] = "Descarta todos los cambios y sale del modo sandbox"
+-- Modules/Changelog/GUI.lua:80
+CLM.L["Do not show again"] = "No mostrar de nuevo"
+-- .:indirectly
+CLM.L["Druid"] = "Druida"
+-- Modules/RosterManager/Roster.lua:656
+CLM.L["EPGP"] = "EPGP"
+-- Modules/AutoAwardManager/EncounterIDs.lua:18
+CLM.L["Ebonroc"] = "Ebanorroca"
+-- Modules/AutoAwardManager/EncounterIDs.lua:54
+CLM.L["Edge of Madness"] = "Edge of Madness"
+-- Global/GlobalConfigs.lua:127
+CLM.L["Enable announcing auction start and end."] = "Habilite anunciar el inicio y el final de la subasta."
+-- Modules/BiddingManager/BiddingManager.lua:75
+CLM.L["Enable auto-update bid values when current highest bid changes (open auction only)."] = "Habilite la actualización automática de los valores de la oferta cuando cambie la oferta más alta actual (solo subasta abierta)."
+-- Modules/BiddingManager/BiddingManager.lua:74
+CLM.L["Enable auto-update bid values"] = "Habilitar valores de oferta de actualización automática"
+-- Modules/AuctionManager/AuctionManager.lua:112
+CLM.L["Enable chat commands"] = "Habilitar comandos de chat"
+-- Modules/AuctionManager/AuctionManager.lua:90
+CLM.L["Enable loot auto-award (Master Looter UI) from corpse when item is awarded"] = "Habilite la concesión automática de botín (interfaz de usuario de Master Looter) del cadáver cuando se otorga el artículo"
+-- Modules/RosterManager/Options.lua:748
+CLM.L["Enable paid value splitting amongst raiders."] = "Habilite la división del valor pagado entre los raiders."
+-- Modules/Logger/Logger.lua:29
+CLM.L["Enables / disables verbose data printing during logging"] = "Habilita/deshabilita la impresión de datos detallados durante el registro"
+-- Global/GlobalConfigs.lua:136
+CLM.L["Enables announcing chat commands at auction start."] = "Habilita anunciar comandos de chat al inicio de la subasta."
+-- Global/GlobalConfigs.lua:154
+CLM.L["Enables announcing loot awards."] = "Permite anunciar premios de botín."
+-- Global/GlobalConfigs.lua:163
+CLM.L["Enables announcing new highest bid (when applicable)."] = "Habilita el anuncio de la nueva oferta más alta (cuando corresponda)."
+-- Global/GlobalConfigs.lua:118
+CLM.L["Enables announcing raid start and end."] = "Permite anunciar el inicio y el final de la raid."
+-- Modules/AuctionManager/AuctionManager.lua:99
+CLM.L["Enables auto-trade awarded loot after auctioning from bag"] = "Permite el intercambio automático de botín después de la subasta."
+-- Global/GlobalConfigs.lua:145
+CLM.L["Enables raid-warning countdown for auctions."] = "Habilita la cuenta regresiva de advertencia de raid para las subastas."
+-- Modules/AuctionManager/AuctionManager.lua:113
+CLM.L["Enble !dkp and !bid through whisper / raid. Change requires /reload."] = "Habilite !dkp y !bid a través de susurro /raid. El cambio requiere /recargar. "
+-- Global/GlobalConfigs.lua:56
+CLM.L["Enble WoW DKP Bot Integration. This will result in additional data stored upon logout."] = "Habilite la integración de WoW DKP Bot. Esto resultará en datos adicionales almacenados al cerrar la sesión."
+-- Modules/LedgerManager/GUI.lua:563
+CLM.L["End Timetravel"] = "Fin de Timetravel"
+-- Modules/RaidManager/GUI.lua:138
+CLM.L["End selected raid"] = "Finalizar raid seleccionada"
+-- Modules/LedgerManager/GUI.lua:476
+CLM.L["Enter sandbox"] = "Entrar en modo Sandbox"
+-- Modules/LootQueueManager/LootQueueManager.lua:86
+-- Global/GlobalConfigs.lua:104
+CLM.L["Epic"] = "Épico"
+-- Modules/AutoAwardManager/EncounterIDs.lua:109
+CLM.L["Eredar Twins"] = "Gemelos Eredar"
+-- Modules/RosterManager/Roster.lua:814
+CLM.L["Europe"] = "Europa"
+-- Modules/RosterManager/GUI.lua:340
+CLM.L["Execute decay for selected players or everyone if none selected."] = "Ejecuta el decaimiento para los jugadores seleccionados o para todos si no se seleccionó ninguno."
+-- Migration.lua:369
+CLM.L["Execute migration from MonolithDKP, EssentialDKP or CommunityDKP"] = "Ejecute la migración desde MonolithDKP, EssentialDKP o CommunityDKP"
+-- Migration.lua:51
+CLM.L["Executing Addon Migration with comms disabled."] = "Ejecutando la migración de complementos con las comunicaciones deshabilitadas."
+-- Global/GlobalSlashCommands.lua:110
+CLM.L["Export data"] = "Exportar datos"
+-- Modules/RosterManager/GUI.lua:126
+-- Modules/ProfileManager/GUI.lua:82
+CLM.L["External"] = "Externo"
+-- Modules/LedgerManager/GUI.lua:38
+CLM.L["False"] = "Falso"
+-- Modules/AutoAwardManager/EncounterIDs.lua:25
+CLM.L["Fankriss the Unyielding"] = "Fankriss el Implacable"
+-- Modules/AutoAwardManager/EncounterIDs.lua:79
+CLM.L["Fathom-Lord Karathress"] = "Señor de las profundidades Karathress"
+-- Modules/RosterManager/Roster.lua:752
+-- Modules/RosterManager/Roster.lua:784
+CLM.L["Feet"] = "Pies"
+-- Modules/AutoAwardManager/EncounterIDs.lua:108
+CLM.L["Felmyst"] = "Brumavil"
+-- Modules/ProfileManager/GUI.lua:178
+CLM.L["Fill from Guild"] = "Rellenar desde la Hermandad"
+-- Modules/ProfileManager/GUI.lua:191
+CLM.L["Fill from Raid Roster"] = "Rellenar desde el roster de raid"
+-- Modules/ProfileManager/GUI.lua:192
+CLM.L["Fill profile list with players in current raid roster."] = "Llene la lista de perfiles con jugadores en el roster de raid actual."
+-- Modules/ProfileManager/GUI.lua:179
+CLM.L["Fill profile list with players with the minimum level and ranks."] = "Llene la lista de perfiles con jugadores con el nivel mínimo y rangos."
+-- Modules/RosterManager/Options.lua:548
+CLM.L["Fill profiles"] = "Rellenar perfiles"
+-- Modules/RosterManager/Options.lua:549
+CLM.L["Fills current roster with all profiles."] = "Llena el roster actual con todos los perfiles."
+-- Modules/RosterManager/GUI.lua:136
+-- Modules/ProfileManager/GUI.lua:90
+CLM.L["Filter"] = "Filtro"
+-- Modules/RosterManager/GUI.lua:132
+-- Modules/ProfileManager/GUI.lua:86
+CLM.L["Filtering"] = "Filtración"
+-- Modules/RosterManager/Roster.lua:753
+-- Modules/RosterManager/Roster.lua:785
+CLM.L["Finger"] = "Dedo"
+-- Modules/LedgerManager/GUI.lua:431
+CLM.L["Finished raid %s"] = "Raid terminada %s"
+-- Modules/RaidManager/RaidManager.lua:804
+CLM.L["Finished"] = "Finalizado"
+-- Modules/AutoAwardManager/EncounterIDs.lua:17
+CLM.L["Firemaw"] = "Faucefogo"
+-- Modules/AutoAwardManager/EncounterIDs.lua:19
+CLM.L["Flamegor"] = "Flamegor"
+-- Global/GlobalSlashCommands.lua:128
+CLM.L["Found %s in guild."] = "Encontrado% s en la Hermandad."
+-- Modules/ProfileManager/GUI.lua:440
+CLM.L["GM"] = "GM"
+-- Modules/AutoAwardManager/EncounterIDs.lua:55
+CLM.L["Gahz'ranka"] = "Gahz'ranka"
+-- Modules/AutoAwardManager/EncounterIDs.lua:7
+CLM.L["Garr"] = "Garr"
+-- Modules/AutoAwardManager/EncounterIDs.lua:6
+CLM.L["Gehennas"] = "Gehennas"
+-- Modules/AutoAwardManager/EncounterIDs.lua:57
+CLM.L["General Rajaxx"] = "General Rajaxx"
+-- Global/GlobalConfigs.lua:42
+CLM.L["Global"] = "Global"
+-- Modules/AutoAwardManager/EncounterIDs.lua:36
+CLM.L["Gluth"] = "Gluth"
+-- Modules/AutoAwardManager/EncounterIDs.lua:11
+CLM.L["Golemagg the Incinerator"] = "Golemagg el Incinerador"
+-- Modules/AutoAwardManager/EncounterIDs.lua:42
+CLM.L["Gothik the Harvester"] = "Gothik el Cosechador"
+-- Modules/AutoAwardManager/EncounterIDs.lua:32
+CLM.L["Grand Widow Faerlina"] = "Gran Viuda Faerlina"
+-- Modules/AutoAwardManager/EncounterIDs.lua:35
+CLM.L["Grobbulus"] = "Grobbulus"
+-- Modules/AutoAwardManager/EncounterIDs.lua:74
+CLM.L["Gruul the Dragonkiller"] = "Gruul el Asesino de Dragones"
+-- Modules/AutoAwardManager/EncounterIDs.lua:240
+CLM.L["Gruul's Lair"] = "Guarida de Gruul"
+-- Modules/AutoAwardManager/EncounterIDs.lua:90
+CLM.L["Gurtogg Bloodboil"] = "Gurtogg Sangre Hirviente"
+-- Modules/AutoAwardManager/EncounterIDs.lua:53
+CLM.L["Hakkar"] = "Hakkar"
+-- Modules/AutoAwardManager/EncounterIDs.lua:103
+CLM.L["Halazzi"] = "Halazzi"
+-- Modules/RosterManager/Roster.lua:749
+-- Modules/RosterManager/Roster.lua:781
+CLM.L["Hands"] = "Manos"
+-- Modules/LedgerManager/GUI.lua:146
+CLM.L["Hard DKP cap"] = "Límite máximo DKP"
+-- Modules/RosterManager/Options.lua:696
+CLM.L["Hard cap"] = "Límite máximo"
+-- Modules/RosterManager/Roster.lua:740
+-- Modules/RosterManager/Roster.lua:772
+CLM.L["Head"] = "Cabeza"
+-- Modules/AutoAwardManager/EncounterIDs.lua:39
+CLM.L["Heigan the Unclean"] = "Heigan el Impuro"
+-- Modules/RosterManager/Roster.lua:758
+-- Modules/RosterManager/Roster.lua:790
+CLM.L["Held In Off-hand"] = "Sostenido en la mano izquierda"
+-- Modules/AutoAwardManager/EncounterIDs.lua:104
+CLM.L["Hex Lord Malacrass"] = "Señor aojador Malacrass"
+-- Modules/AuctionManager/AuctionManager.lua:122
+CLM.L["Hides incoming !dkp and !bid whispers. Change requires /reload."] = "Oculta los susurros entrantes de !dkp y !bid. El cambio requiere /recargar."
+-- Modules/AuctionManager/AuctionManager.lua:131
+CLM.L["Hides outgoing !dkp and !bid responses. Change requires /reload."] = "Oculta las respuestas !dkp y !bid salientes. El cambio requiere /recargar."
+-- Modules/AutoAwardManager/EncounterIDs.lua:84
+CLM.L["High Astromancer Solarian"] = "Gran astromántica Solarian"
+-- Modules/AutoAwardManager/EncounterIDs.lua:73
+CLM.L["High King Maulgar"] = "Su majestad Maulgar"
+-- Modules/AutoAwardManager/EncounterIDs.lua:46
+CLM.L["High Priest Thekal"] = "Sumo Sacerdote Thekal"
+-- Modules/AutoAwardManager/EncounterIDs.lua:47
+CLM.L["High Priest Venoxis"] = "Sumo Sacerdote Venoxis"
+-- Modules/AutoAwardManager/EncounterIDs.lua:48
+CLM.L["High Priestess Arlokk"] = "Suma Sacerdotisa Arlokk"
+-- Modules/AutoAwardManager/EncounterIDs.lua:49
+CLM.L["High Priestess Jeklik"] = "Suma Sacerdotisa Jeklik"
+-- Modules/AutoAwardManager/EncounterIDs.lua:50
+CLM.L["High Priestess Mar'li"] = "Suma Sacerdotisa Mar'li"
+-- Modules/AutoAwardManager/EncounterIDs.lua:86
+CLM.L["High Warlord Naj'entus"] = "Gran Señor de la Guerra Naj'entus"
+-- .:indirectly
+CLM.L["Hunter"] = "Cazador"
+-- Modules/AutoAwardManager/EncounterIDs.lua:76
+CLM.L["Hydross the Unstable"] = "Hydross el Inestable"
+-- Modules/AutoAwardManager/EncounterIDs.lua:292
+CLM.L["Hyjal Summit"] = "Monte Hyjal"
+-- Global/GlobalSlashCommands.lua:54
+CLM.L["Ignore entry"] = "Ignorar entrada"
+-- Modules/LootQueueManager/LootQueueManager.lua:94
+CLM.L["Ignore"] = "Ignorar"
+-- Modules/AutoAwardManager/EncounterIDs.lua:94
+CLM.L["Illidan Stormrage"] = "Illidan Tempestira"
+-- Modules/BiddingManager/GUI.lua:263
+CLM.L["Immediately bid base item value."] = "Oferte inmediatamente el valor del artículo base."
+-- Modules/BiddingManager/GUI.lua:280
+CLM.L["Immediately bid max item value."] = "Oferte inmediatamente por el valor máximo del artículo. "
+-- Migration.lua:227
+-- Migration.lua:361
+CLM.L["Import complete"] = "Importación completa"
+-- Modules/PointManager/PointManager.lua:421
+CLM.L["Import"] = "Importar"
+-- Migration.lua:178
+CLM.L["Importing %s entries from DKPTable"] = "Importación de entradas %s de la tabla DKP"
+-- Migration.lua:289
+CLM.L["Importing profiles from DKPTable"] = "Importación de perfiles desde la tabla DKP"
+-- Modules/RosterManager/GUI.lua:127
+-- Modules/ProfileManager/GUI.lua:81
+CLM.L["In Guild"] = "En la Hermandad"
+-- Modules/RaidManager/RaidManager.lua:803
+CLM.L["In Progress"] = "En curso"
+-- Modules/RaidManager/GUI.lua:419
+-- Modules/RosterManager/GUI.lua:124
+-- Modules/ProfileManager/GUI.lua:80
+CLM.L["In Raid"] = "En Raid"
+-- Modules/LedgerManager/GUI.lua:477
+CLM.L["In sandbox mode all communication is disabled and changes are local until applied. Click Apply changes to store changes and exit sandbox mode. Click Discard to undo changes and exit sandbox mode. /reload will discard changes. Entering sandbox mode will cancel time travel."] = "En el modo sandbox, todas las comunicaciones están deshabilitadas y los cambios son locales hasta que se apliquen. Haga clic en Aplicar cambios para almacenar los cambios y salir del modo Sandbox. Haga clic en Descartar para descartar los cambios y salir del modo Sandbox. /reload deshará los cambios. Entrar en el modo Sandbox cancelará Timetravel."
+-- MinimapIcon.lua:134
+CLM.L["In-Sync"] = "En Sincronización"
+-- Modules/RaidManager/GUI.lua:289
+-- Modules/RosterManager/Options.lua:646
+-- Modules/LedgerManager/GUI.lua:164
+CLM.L["Include bench"] = "Incluir banquillo"
+-- Modules/RaidManager/GUI.lua:290
+-- Modules/RosterManager/Options.lua:647
+CLM.L["Include benched players in all auto-awards"] = "Incluir jugadores en el banquillo en todas las recompensas automáticas"
+-- Modules/RosterManager/GUI.lua:331
+CLM.L["Include players with negative standings."] = "Incluir jugadores con valoraciones negativas."
+-- MinimapIcon.lua:132
+CLM.L["Incoherent state"] = "Estado incoherente"
+-- Modules/RosterManager/GUI.lua:644
+CLM.L["Information"] = "Información"
+-- Global/GlobalSlashCommands.lua:123
+CLM.L["Input name: %s"] = "Nombre de entrada: %s"
+-- Modules/AutoAwardManager/EncounterIDs.lua:41
+CLM.L["Instructor Razuvious"] = "Instructor Razuvious"
+-- Modules/LedgerManager/GUI.lua:140
+CLM.L["Interval Bonus time"] = "Tiempo de bonificación de intervalo"
+-- Modules/RaidManager/GUI.lua:214
+-- Modules/RaidManager/GUI.lua:266
+-- Modules/RosterManager/Options.lua:622
+-- Modules/PointManager/PointManager.lua:423
+-- Modules/LedgerManager/GUI.lua:137
+CLM.L["Interval Bonus"] = "Bono de intervalo"
+-- Modules/RaidManager/GUI.lua:216
+-- Modules/RaidManager/GUI.lua:273
+-- Modules/RosterManager/Options.lua:629
+CLM.L["Interval Time"] = "Tiempo de intervalo"
+-- Modules/RaidManager/GUI.lua:217
+-- Modules/RaidManager/GUI.lua:281
+-- Modules/RosterManager/Options.lua:638
+-- Modules/LedgerManager/GUI.lua:143
+CLM.L["Interval Value"] = "Valor de bonificación de intervalo"
+-- Modules/RosterManager/Options.lua:630
+CLM.L["Interval in [minutes] to award bonus points"] = "Intervalo en [minutos] para otorgar puntos de bonificación"
+-- Modules/AuctionManager/AuctionManager.lua:664
+CLM.L["Invalid bid value"] = "Valor de oferta no válido"
+-- Global/GlobalSlashCommands.lua:167
+CLM.L["Invalid item link"] = "Enlace de artículo no válido"
+-- Global/GlobalChatMessageHandlers.lua:60
+CLM.L["Invalid value provided"] = "Valor proporcionado no válido"
+-- Modules/LedgerManager/GUI.lua:98
+CLM.L["Item Value Mode"] = "Modo de valor del artículo"
+-- Modules/RosterManager/Options.lua:739
+CLM.L["Item value mode"] = "Modo de valor del artículo"
+-- Global/GlobalSlashCommands.lua:173
+CLM.L["Item value must be positive"] = "El valor del artículo debe ser positivo"
+-- Modules/RosterManager/Options.lua:815
+CLM.L["Item value overrides"] = "Reemplazos del valor del artículo"
+-- Modules/BiddingManager/GUI.lua:236
+-- Modules/AuctionManager/GUI.lua:324
+-- Modules/LootManager/GUI.lua:93
+-- Modules/LootManager/GUI.lua:100
+CLM.L["Item"] = "Articulo"
+-- Modules/AutoAwardManager/EncounterIDs.lua:102
+CLM.L["Jan'alai"] = "Jan'alai"
+-- Modules/AutoAwardManager/EncounterIDs.lua:52
+CLM.L["Jin'do the Hexxer"] = "Jin'do el Malhechor"
+-- Global/GlobalConfigs.lua:36
+CLM.L["Join our discord for more info: |cff44cc44https://tiny.one/clm-discord|r"] = "Únete a nuestro discord para más información: |cff44cc44https://tiny.one/clm-discord|r"
+-- Modules/RaidManager/GUI.lua:152
+CLM.L["Join selected raid"] = "Unirse a la raid seleccionada"
+-- Modules/AutoAwardManager/EncounterIDs.lua:85
+CLM.L["Kael'thas Sunstrider"] = "Kael'thas Caminante del Sol "
+-- Modules/AutoAwardManager/EncounterIDs.lua:106
+CLM.L["Kalecgos"] = "Kalecgos"
+-- Modules/AutoAwardManager/EncounterIDs.lua:223
+CLM.L["Karazhan"] = "Karazhan"
+-- Modules/AutoAwardManager/EncounterIDs.lua:97
+CLM.L["Kaz'rogal"] = "Kaz'rogal"
+-- Modules/AutoAwardManager/EncounterIDs.lua:45
+CLM.L["Kel'Thuzad"] = "Kel'Thuzad"
+-- Modules/AutoAwardManager/EncounterIDs.lua:111
+CLM.L["Kil'jaeden"] = "Kil'jaeden"
+-- Modules/AutoAwardManager/EncounterIDs.lua:56
+CLM.L["Kurinnaxx"] = "Kurinnaxx"
+-- Modules/AutoAwardManager/EncounterIDs.lua:81
+CLM.L["Lady Vashj"] = "Lady Vashj"
+-- Modules/RosterManager/GUI.lua:676
+CLM.L["Latest DKP changes:"] = "Últimos cambios de DKP:"
+-- Modules/RosterManager/GUI.lua:657
+CLM.L["Latest loot:"] = "Último botín:"
+-- Modules/LedgerManager/GUI.lua:602
+CLM.L["Ledger Entries Audit"] = "Auditoría de asientos contables"
+-- Modules/LootQueueManager/LootQueueManager.lua:87
+-- Global/GlobalConfigs.lua:105
+CLM.L["Legendary"] = "Legendaria"
+-- Modules/RosterManager/Roster.lua:751
+-- Modules/RosterManager/Roster.lua:783
+CLM.L["Legs"] = "Piernas"
+-- Modules/AutoAwardManager/EncounterIDs.lua:78
+CLM.L["Leotheras the Blind"] = "Leotheras el Ciego"
+-- Global/GlobalSlashCommands.lua:35
+CLM.L["Link Alt to Main"] = "Vincular Alter a Main"
+-- Modules/PointManager/PointManager.lua:424
+CLM.L["Linking override"] = "Anulación de vinculación"
+-- MinimapIcon.lua:128
+-- Modules/LootManager/GUI.lua:300
+-- Modules/LedgerManager/GUI.lua:510
+CLM.L["Loading..."] = "Cargando..."
+-- Modules/AutoAwardManager/EncounterIDs.lua:40
+CLM.L["Loatheb"] = "Loatheb"
+-- Modules/Logger/Logger.lua:19
+CLM.L["Logging level"] = "Nivel de registro"
+-- Modules/Logger/Logger.lua:15
+CLM.L["Logging"] = "Inicio sesión"
+-- Global/GlobalConfigs.lua:153
+CLM.L["Loot Awards"] = "Premios de botín"
+-- MinimapIcon.lua:31
+-- Modules/LootManager/GUI.lua:238
+CLM.L["Loot History"] = "Historial de botín"
+-- MinimapIcon.lua:56
+-- Modules/LootQueueManager/GUI.lua:185
+-- Modules/LootQueueManager/LootQueueManager.lua:73
+CLM.L["Loot Queue"] = "Cola de botín"
+-- Modules/AutoAwardManager/EncounterIDs.lua:4
+CLM.L["Lucifron"] = "Lucifron"
+-- Modules/AutoAwardManager/EncounterIDs.lua:110
+CLM.L["M'uru"] = "M'uru"
+-- Modules/AutoAwardManager/EncounterIDs.lua:33
+CLM.L["Maexxna"] = "Maexxna"
+-- .:indirectly
+CLM.L["Mage"] = "Mago"
+-- Modules/AutoAwardManager/EncounterIDs.lua:5
+CLM.L["Magmadar"] = "Magmadar"
+-- Modules/AutoAwardManager/EncounterIDs.lua:75
+-- Modules/AutoAwardManager/EncounterIDs.lua:248
+CLM.L["Magtheridon"] = "Magtheridon"
+-- Modules/AutoAwardManager/EncounterIDs.lua:64
+CLM.L["Maiden of Virtue"] = "Doncella de Virtud"
+-- Modules/RosterManager/Roster.lua:756
+-- Modules/RosterManager/Roster.lua:788
+CLM.L["Main Hand"] = "Mano Principal"
+-- Modules/ProfileManager/GUI.lua:383
+CLM.L["Main"] = "Mano"
+-- Modules/RosterManager/GUI.lua:125
+CLM.L["Mains"] = "Manos"
+-- Modules/AutoAwardManager/EncounterIDs.lua:12
+CLM.L["Majordomo Executus"] = "Mayordomo Executus"
+-- Modules/RosterManager/GUI.lua:225
+-- Modules/ProfileManager/GUI.lua:152
+CLM.L["Management"] = "Gestión"
+-- Modules/ProfileManager/GUI.lua:442
+CLM.L["Manager"] = "Gerente"
+-- Modules/PointManager/PointManager.lua:417
+CLM.L["Manual adjustment"] = "Ajuste manual"
+-- Modules/ProfileManager/GUI.lua:241
+CLM.L["Mark as alt"] = "Marcar como alter"
+-- Modules/ProfileManager/GUI.lua:242
+CLM.L["Marks selected profiles or everyone if none selected as alts of choosen player (from dropdown)."] = "Marca los perfiles seleccionados o todos, si ninguno seleccionó, como alternativos del jugador elegido (del menú desplegable)."
+-- Modules/BiddingManager/GUI.lua:279
+-- Modules/AuctionManager/GUI.lua:394
+-- Modules/RosterManager/Options.lua:388
+CLM.L["Max"] = "Маx"
+-- Modules/BiddingManager/GUI.lua:437
+CLM.L["Max: %d "] = "Маx: %d "
+-- Modules/AuctionManager/AuctionManager.lua:240
+CLM.L["Maximum bid: %s."] = "Oferta máxima: %s."
+-- Modules/RosterManager/Options.lua:688
+CLM.L["Maximum point cap player can receive per raid week. Set to 0 to disable."] = "Máximo límite de puntos que el jugador puede recibir por semana de incursión. Establecer en 0 para deshabilitar. "
+-- Modules/RosterManager/Options.lua:697
+CLM.L["Maximum point cap that player can have. Set to 0 to disable."] = "Límite máximo de puntos que puede tener el jugador. Establecer en 0 para deshabilitar. "
+-- Modules/RosterManager/Options.lua:319
+CLM.L["Maximum value for Ascending auction. Set to 0 to ignore."] = "Valor máximo para subasta Ascendente. Establecer en 0 para ignorar. "
+-- MinimapIcon.lua:23
+CLM.L["Menu"] = "Menú"
+-- Migration.lua:165
+-- Migration.lua:243
+CLM.L["Migrating %s"] = "Migrando %s"
+-- Migration.lua:63
+CLM.L["Migration complete. %s to apply and sync with others or go to %s to discard."] = "Migración completa. %s para aplicar y sincronizar con otros o ir a %s para descartar. "
+-- Migration.lua:266
+CLM.L["Migration failure: Detected 0 teams"] = "Error de migración: 0 equipos detectados"
+-- Migration.lua:204
+-- Migration.lua:320
+CLM.L["Migration failure: Unable to create profiles"] = "Error de migración: no se pueden crear perfiles"
+-- Migration.lua:34
+CLM.L["Migration ongoing: %s(%s)"] = "Migración en curso: %s(%s)"
+-- Modules/LedgerManager/GUI.lua:158
+CLM.L["Min bid increment"] = "Incremento mínimo de oferta"
+-- Modules/RosterManager/Options.lua:776
+CLM.L["Minimal increment"] = "Incremento mínimo"
+-- Modules/RosterManager/Options.lua:777
+CLM.L["Minimal value increment for open auction mode."] = "Incremento de valor mínimo para el modo de subasta abierta."
+-- Migration.lua:65
+CLM.L["Minimap Icon -> Configuration -> Wipe events"] = "Ícono del minimapa -> Configuración -> Borrar eventos"
+-- Modules/ProfileManager/GUI.lua:165
+CLM.L["Minimum Level"] = "Nivel mínimo"
+-- Modules/AuctionManager/AuctionManager.lua:237
+CLM.L["Minimum bid: %s."] = "Oferta mínima: %s."
+-- Modules/ProfileManager/GUI.lua:166
+CLM.L["Minimum level of players to fill from guild."] = "Nivel mínimo de jugadores para llenar de la Hermandad."
+-- Global/GlobalSlashCommands.lua:206
+CLM.L["Missing profile %s"] = "Perfil faltante %s"
+-- Global/GlobalSlashCommands.lua:184
+CLM.L["Missing roster name and you are not in raid"] = "Falta el nombre del roster y no estás en raid"
+-- Global/GlobalSlashCommands.lua:188
+CLM.L["Missing roster name. Using Raid Info"] = "Falta el nombre del roster. Uso de información de la raid"
+-- Modules/RaidManager/RaidManager.lua:377
+-- Modules/RaidManager/RaidManager.lua:433
+-- Modules/RaidManager/RaidManager.lua:462
+-- Modules/RaidManager/RaidManager.lua:491
+-- Modules/RaidManager/RaidManager.lua:525
+CLM.L["Missing valid raid"] = "Falta una raid válida"
+-- Modules/AutoAwardManager/EncounterIDs.lua:58
+CLM.L["Moam"] = "Moam"
+-- Modules/AutoAwardManager/EncounterIDs.lua:126
+CLM.L["Molten Core"] = "Nucleo de Magma"
+-- Modules/AutoAwardManager/EncounterIDs.lua:63
+CLM.L["Moroes"] = "Moroes"
+-- Modules/AutoAwardManager/EncounterIDs.lua:80
+CLM.L["Morogrim Tidewalker"] = "Morogrim Levantamareas"
+-- Modules/AutoAwardManager/EncounterIDs.lua:92
+CLM.L["Mother Shahraz"] = "Madre Shahraz"
+-- Modules/AutoAwardManager/EncounterIDs.lua:101
+CLM.L["Nalorakk"] = "Nalorakk"
+-- Modules/RaidManager/GUI.lua:387
+-- Modules/AuctionManager/GUI.lua:227
+-- Modules/RosterManager/GUI.lua:476
+-- Modules/RosterManager/Options.lua:488
+-- Modules/ProfileManager/GUI.lua:374
+CLM.L["Name"] = "Nombre"
+-- Modules/AutoAwardManager/EncounterIDs.lua:171
+CLM.L["Naxxramas"] = "Naxxramas"
+-- Modules/RosterManager/Roster.lua:741
+-- Modules/RosterManager/Roster.lua:773
+CLM.L["Neck"] = "Cuello"
+-- Modules/AutoAwardManager/EncounterIDs.lua:21
+CLM.L["Nefarian"] = "Nefarian"
+-- Modules/AuctionManager/AuctionManager.lua:660
+CLM.L["Negative bidders not allowed"] = "Postores negativos no autorizados"
+-- Modules/RosterManager/GUI.lua:330
+CLM.L["Negatives"] = "Negativos"
+-- Modules/AutoAwardManager/EncounterIDs.lua:69
+CLM.L["Netherspite"] = "Rencor abisal"
+-- Modules/Changelog/GUI.lua:40
+CLM.L["Never show changelog"] = "Nunca mostrar el registro de cambios"
+-- Modules/AuctionManager/AuctionManager.lua:415
+CLM.L["New highest bid: %d DKP %s"] = "Nueva oferta más alta: %d DKP %s"
+-- Migration.lua:91
+CLM.L["New roster: [%s]"] = "Nuevo roster: [%s]"
+-- Modules/ProfileInfoManager/ProfileInfoManager.lua:69
+CLM.L["New version %s of Classic Loot Manager is available. For best experience please update the AddOn."] = "La nueva versión %s de Classic Loot Manager está disponible. Para obtener la mejor experiencia, actualice el AddOn."
+-- Modules/AutoAwardManager/EncounterIDs.lua:72
+CLM.L["Nightbane"] = "Nocturno"
+-- Modules/AuctionManager/AuctionManager.lua:666
+CLM.L["No auction in progress"] = "No hay subasta en curso"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:50
+-- Modules/AuctionHistoryManager/GUI.lua:152
+CLM.L["No bids"] = "Sin ofertas"
+-- Modules/RosterManager/GUI.lua:670
+CLM.L["No loot received"] = "No se recibió botín"
+-- Modules/RosterManager/GUI.lua:687
+CLM.L["No points received"] = "No se recibieron puntos"
+-- Modules/ProfileManager/GUI.lua:477
+CLM.L["No profile for "] = "Sin perfil para "
+-- Utils.lua:452
+CLM.L["No"] = "No"
+-- Modules/RosterManager/Roster.lua:763
+-- Modules/RosterManager/Roster.lua:795
+CLM.L["Non-equippable"] = "No equipable"
+-- Modules/RaidManager/GUI.lua:430
+-- Modules/RosterManager/GUI.lua:205
+-- Modules/PointManager/GUI.lua:141
+-- Modules/ProfileManager/GUI.lua:123
+CLM.L["None"] = "Ninguno"
+-- Modules/AuctionManager/AuctionManager.lua:659
+CLM.L["Not in a roster"] = "No en un roster"
+-- Modules/RaidManager/GUI.lua:524
+-- Modules/RosterManager/GUI.lua:515
+-- Modules/RosterManager/GUI.lua:558
+CLM.L["Not in raid"] = "No en raid"
+-- Modules/RosterManager/GUI.lua:241
+CLM.L["Note to be added to award. Max 32 characters. It is recommended to not include date nor selected reason here. If you will input encounter ID it will be transformed into boss name."] = "Nota para ser añadida al premio. 32 caracteres como máximo. Se recomienda no incluir fecha ni motivo seleccionado aquí. Si ingresa la identificación del encuentro, se transformará en el nombre del jefe."
+-- Modules/AuctionManager/GUI.lua:344
+-- Modules/AuctionManager/GUI.lua:350
+-- Modules/RosterManager/GUI.lua:239
+-- Modules/PointManager/GUI.lua:178
+CLM.L["Note"] = "Nota"
+-- Modules/AutoAwardManager/EncounterIDs.lua:38
+CLM.L["Noth the Plaguebringer"] = "Noth el Pesteador"
+-- Modules/BiddingManager/GUI.lua:310
+CLM.L["Notify that you are passing on the item. Cancels any existing bids."] = "Notifique que está pasando el artículo. Cancela cualquier oferta existente."
+-- Modules/BiddingManager/GUI.lua:308
+CLM.L["Notify that you are passing on the item."] = "Notifique que está pasando el artículo."
+-- Modules/LedgerManager/GUI.lua:52
+CLM.L["Num"] = "Número"
+-- Modules/RosterManager/Roster.lua:757
+-- Modules/RosterManager/Roster.lua:789
+CLM.L["Off Hand"] = "Mano izquierda"
+-- Modules/RaidManager/GUI.lua:206
+-- Modules/RaidManager/GUI.lua:243
+-- Modules/RosterManager/Options.lua:599
+CLM.L["On Time Bonus Value"] = "Valor de bonificación a tiempo"
+-- Modules/LedgerManager/GUI.lua:128
+CLM.L["On Time Bonus value"] = "Valor de bonificación a tiempo"
+-- Modules/RaidManager/GUI.lua:204
+-- Modules/RaidManager/GUI.lua:236
+-- Modules/RosterManager/Options.lua:592
+-- Modules/PointManager/PointManager.lua:410
+-- Modules/LedgerManager/GUI.lua:125
+CLM.L["On Time Bonus"] = "Bono de tiempo"
+-- Modules/RosterManager/Roster.lua:755
+-- Modules/RosterManager/Roster.lua:787
+CLM.L["One-Hand"] = "Una mano"
+-- Modules/RosterManager/Options.lua:654
+-- Modules/LedgerManager/GUI.lua:167
+CLM.L["Online only"] = "solo online"
+-- Global/GlobalConfigs.lua:86
+CLM.L["Only when ML/RL"] = "Solo cuando ML/RL"
+-- Modules/AutoAwardManager/EncounterIDs.lua:3
+CLM.L["Onyxia"] = "Onyxia"
+-- Modules/AutoAwardManager/EncounterIDs.lua:119
+CLM.L["Onyxia's Lair"] = "Guarida de Onyxia"
+-- Modules/RosterManager/Roster.lua:676
+CLM.L["Open"] = "Abierto"
+-- Modules/AutoAwardManager/EncounterIDs.lua:65
+CLM.L["Opera Hall"] = "Ópera"
+-- Modules/AutoAwardManager/EncounterIDs.lua:61
+CLM.L["Ossirian the Unscarred"] = "Osirio el Sinmarcas"
+-- Modules/AutoAwardManager/EncounterIDs.lua:29
+CLM.L["Ouro"] = "Ouro"
+-- Modules/RaidManager/GUI.lua:225
+CLM.L["Overrides"] = "Reemplaza"
+-- Modules/BiddingManager/BiddingManager.lua:137
+-- Modules/AuctionManager/AuctionManager.lua:617
+CLM.L["PASS"] = "PASAR"
+-- .:indirectly
+CLM.L["Paladin"] = "Paladín"
+-- Modules/RaidManager/GUI.lua:417
+CLM.L["Participated"] = "participó"
+-- Modules/BiddingManager/GUI.lua:305
+CLM.L["Pass"] = "Pasar"
+-- Modules/AuctionManager/AuctionManager.lua:668
+CLM.L["Passing after bidding not allowed"] = "Pasar después de pujar no está permitido"
+-- Modules/AutoAwardManager/EncounterIDs.lua:34
+CLM.L["Patchwerk"] = "Remendejo"
+-- Modules/LootManager/GUI.lua:103
+CLM.L["Player"] = "Jugador"
+-- Modules/RaidManager/GUI.lua:103
+-- Modules/RaidManager/GUI.lua:115
+CLM.L["Please select a raid"] = "Seleccione una raid"
+-- MinimapIcon.lua:35
+-- Modules/PointManager/GUI.lua:217
+CLM.L["Point History"] = "Historial de puntos"
+-- Modules/RosterManager/Options.lua:672
+CLM.L["Point caps"] = "Límite de puntos"
+-- Modules/RosterManager/Options.lua:495
+-- Modules/RosterManager/Options.lua:849
+CLM.L["Point type"] = "Tipo de punto"
+-- Modules/LootQueueManager/LootQueueManager.lua:82
+-- Global/GlobalConfigs.lua:100
+CLM.L["Poor"] = "Pobre"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:74
+CLM.L["Post bids"] = "Publicar ofertas"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:83
+CLM.L["Post channel"] = "Publicar canal"
+-- .:indirectly
+CLM.L["Priest"] = "Sacerdote"
+-- Modules/AutoAwardManager/EncounterIDs.lua:71
+CLM.L["Prince Malchezaar"] = "Principe Malchezaar"
+-- Modules/AutoAwardManager/EncounterIDs.lua:27
+CLM.L["Princess Huhuran"] = "Princesa Huhuran"
+-- MinimapIcon.lua:69
+-- Modules/ProfileManager/GUI.lua:404
+CLM.L["Profiles"] = "Perfiles"
+-- Modules/PointManager/PointManager.lua:413
+CLM.L["Progression Bonus"] = "Progreso del Bonus"
+-- Modules/RosterManager/RosterManager.lua:271
+CLM.L["Provide number of raids needed for 100% attendance in a weekly reset. Between 1 - 50 raids. Defaults to 2. Requires /reload."] = "Proporcione la cantidad de redadas necesarias para el 100 % de asistencia en un reinicio semanal. Entre 1 - 50 redadas. El valor predeterminado es 2. Requiere /recargar."
+-- Modules/RosterManager/RosterManager.lua:289
+CLM.L["Provide number of weeks that will be accounted for attendance. Between 1 - 1000 weeks. Defaults to 10. Requires /reload."] = "Proporcione el número de semanas que se contabilizarán como asistencia. Entre 1 - 1000 semanas. El valor predeterminado es 10. Requiere /recargar."
+-- Global/GlobalSlashCommands.lua:68
+CLM.L["Prune profiles"] = "Cortar los perfiles"
+-- Modules/RaidManager/GUI.lua:298
+-- Modules/RosterManager/Options.lua:720
+CLM.L["Put players leaving raid on bench instead of removing them. To remove them completely they will need to be removed manually from the bench."] = "Poner a los jugadores que salen de raid en el banquillo en lugar de eliminarlos. Para eliminarlos por completo, será necesario retirarlos manualmente del banquillo. "
+-- Modules/RosterManager/Roster.lua:767
+-- Modules/RosterManager/Roster.lua:799
+CLM.L["Quiver"] = "Carcaj"
+-- Modules/RosterManager/Roster.lua:657
+CLM.L["ROLL"] = "Tirada de dados"
+-- Modules/AutoAwardManager/EncounterIDs.lua:95
+CLM.L["Rage Winterchill"] = "Ira Fríoinvierno"
+-- Modules/AutoAwardManager/EncounterIDs.lua:13
+CLM.L["Ragnaros"] = "Ragnaros"
+-- Modules/RaidManager/GUI.lua:211
+CLM.L["Raid Completion Bonus Value"] = "Valor de bonificación por finalización de raid"
+-- Modules/LedgerManager/GUI.lua:134
+CLM.L["Raid Completion Bonus value"] = "Valor de bonificación por finalización de raid"
+-- Modules/RaidManager/GUI.lua:209
+-- Modules/RaidManager/GUI.lua:251
+-- Modules/RosterManager/Options.lua:607
+-- Modules/PointManager/PointManager.lua:412
+-- Modules/LedgerManager/GUI.lua:131
+CLM.L["Raid Completion Bonus"] = "Bono de finalización de raid"
+-- Modules/RaidManager/GUI.lua:258
+-- Modules/RosterManager/Options.lua:614
+CLM.L["Raid Completion Value"] = "Valor de finalización de raid"
+-- Modules/RaidManager/GUI.lua:341
+CLM.L["Raid Name"] = "Nombre de la raid"
+-- Global/GlobalConfigs.lua:117
+CLM.L["Raid Start/End"] = "Inicio/fin de raid"
+-- Global/GlobalConfigs.lua:113
+CLM.L["Raid Warnings"] = "Advertencias de raid"
+-- Modules/RaidManager/RaidManager.lua:455
+CLM.L["Raid [%s] ended"] = "Raid [%s] finalizada"
+-- Modules/RaidManager/RaidManager.lua:425
+CLM.L["Raid [%s] started"] = "Raid [%s] iniciada"
+-- Modules/RaidManager/RaidManager.lua:367
+-- Modules/RaidManager/RaidManager.lua:389
+-- Modules/RaidManager/RaidManager.lua:445
+-- Modules/RaidManager/RaidManager.lua:478
+-- Modules/RaidManager/RaidManager.lua:503
+-- Modules/RaidManager/RaidManager.lua:537
+CLM.L["Raid management is disabled during time traveling."] = "La gestion de las raids está desactivada durante el Time-traveling"
+-- Global/GlobalSlashCommands.lua:190
+CLM.L["Raid: %s Roster: %s"] = "Raid : %s Roster : %s"
+-- Modules/RosterManager/RosterManager.lua:270
+CLM.L["Raids needed in reset"] = "Raids necesarias para reiniciar"
+-- MinimapIcon.lua:39
+-- Modules/RaidManager/GUI.lua:474
+CLM.L["Raids"] = "Raids"
+-- Modules/RosterManager/Roster.lua:762
+-- Modules/RosterManager/Roster.lua:794
+CLM.L["Ranged (wands)"] = "A distancia (varitas)"
+-- Modules/RosterManager/Roster.lua:761
+-- Modules/RosterManager/Roster.lua:793
+CLM.L["Ranged"] = "A distancia"
+-- Modules/ProfileManager/GUI.lua:384
+CLM.L["Rank"] = "Rango"
+-- Modules/ProfileManager/GUI.lua:156
+CLM.L["Ranks"] = "Rangos"
+-- Modules/LootQueueManager/LootQueueManager.lua:85
+-- Global/GlobalConfigs.lua:103
+CLM.L["Rare"] = "Raro"
+-- Modules/AutoAwardManager/EncounterIDs.lua:14
+CLM.L["Razorgore the Untamed"] = "Sangrevaja el Indomable"
+-- Modules/RosterManager/GUI.lua:254
+-- Modules/PointManager/GUI.lua:94
+CLM.L["Reason"] = "Razón"
+-- Modules/RosterManager/Roster.lua:768
+-- Modules/RosterManager/Roster.lua:800
+CLM.L["Relic"] = "Reliquia"
+-- Modules/AutoAwardManager/EncounterIDs.lua:91
+CLM.L["Reliquary of Souls"] = "Relicario de almas"
+-- Modules/AuctionHistoryManager/GUI.lua:91
+-- Modules/LootQueueManager/GUI.lua:86
+CLM.L["Remove all"] = "Eliminar todo"
+-- Modules/AuctionHistoryManager/GUI.lua:67
+CLM.L["Remove auction"] = "Eliminar subasta"
+-- Modules/RosterManager/GUI.lua:602
+CLM.L["Remove from roster"] = "Eliminar del roster"
+-- Modules/RosterManager/GUI.lua:555
+CLM.L["Remove from standby"] = "Quitar del modo de espera"
+-- Modules/LootQueueManager/GUI.lua:73
+CLM.L["Remove item"] = "Remover el artículo"
+-- Modules/LedgerManager/GUI.lua:247
+CLM.L["Remove linking of "] = "Quitar enlace de "
+-- Modules/AuctionHistoryManager/GUI.lua:80
+CLM.L["Remove old"] = "Eliminar viejo"
+-- Modules/RosterManager/Options.lua:556
+CLM.L["Remove roster"] = "Quitar roster"
+-- Modules/RaidManager/GUI.lua:171
+CLM.L["Remove selected raid"] = "Quitar la raid seleccionada"
+-- Modules/PointManager/GUI.lua:74
+-- Modules/LootManager/GUI.lua:68
+-- Modules/LedgerManager/GUI.lua:575
+CLM.L["Remove selected"] = "Eliminar la selección"
+-- Modules/RosterManager/Options.lua:562
+-- Modules/ProfileManager/GUI.lua:216
+-- Modules/LedgerManager/GUI.lua:309
+CLM.L["Remove"] = "Eliminar"
+-- Modules/RosterManager/Options.lua:563
+CLM.L["Removes current roster."] = "Elimina el roster actual."
+-- Modules/ProfileManager/GUI.lua:217
+CLM.L["Removes selected profiles or everyone if none selected."] = "Elimina los perfiles seleccionados o todos si no se seleccionó ninguno."
+-- Modules/RaidManager/GUI.lua:96
+CLM.L["Request standby"] = "Solicitar espera"
+-- Global/GlobalSlashCommands.lua:147
+CLM.L["Reset gui positions"] = "Restablecer posiciones de interfaz gráfica de usuario"
+-- Modules/RaidManager/GUI.lua:108
+CLM.L["Revoke standby"] = "Revocar modo de espera"
+-- .:indirectly
+CLM.L["Rogue"] = "Pícaro"
+-- Modules/RosterManager/Options.lua:841
+CLM.L["Roster Name"] = "Nombre del roster"
+-- Modules/RosterManager/Options.lua:840
+CLM.L["Roster name"] = "Nombre del roster"
+-- Modules/RaidManager/GUI.lua:389
+CLM.L["Roster"] = "Roster"
+-- Modules/ConfigManager/ConfigManager.lua:132
+-- Modules/ConfigManager/ConfigManager.lua:138
+-- Modules/ConfigManager/ConfigManager.lua:144
+CLM.L["Rosters"] = "Rosters"
+-- Modules/RosterManager/Options.lua:511
+CLM.L["Round to selected number of decimals"] = "Redondear al número seleccionado de decimales"
+-- Modules/LedgerManager/GUI.lua:155
+CLM.L["Round to"] = "Redondear a"
+-- Modules/RosterManager/Options.lua:510
+CLM.L["Rounding"] = "Redondeo"
+-- Modules/AutoAwardManager/EncounterIDs.lua:208
+CLM.L["Ruins of Ahn'Qiraj"] = "Ruinas de Ahn'Qiraj"
+-- Modules/RosterManager/Roster.lua:658
+CLM.L["SK"] = "SK"
+-- Modules/RosterManager/Options.lua:663
+-- Modules/LedgerManager/GUI.lua:170
+CLM.L["Same zone only"] = "Solo la misma zona"
+-- MinimapIcon.lua:142
+CLM.L["Sandbox mode"] = "Sandbox mode"
+-- Modules/AutoAwardManager/EncounterIDs.lua:44
+CLM.L["Sapphiron"] = "Saphiron"
+-- Modules/RosterManager/Roster.lua:677
+CLM.L["Sealed"] = "Sellado"
+-- Modules/RosterManager/GUI.lua:163
+CLM.L["Search for player names. Separate multiple with a comma ','. Minimum 3 characters. Overrides filtering."] = "Buscar nombres de jugadores. Separe los múltiplos con una coma ','. Un mínimo de 3 caracteres. Anula el filtrado."
+-- Modules/RosterManager/GUI.lua:162
+-- Modules/LootManager/GUI.lua:133
+CLM.L["Search"] = "Búsqueda"
+-- Modules/RosterManager/GUI.lua:192
+-- Modules/ProfileManager/GUI.lua:111
+CLM.L["Select all classes."] = "Seleccione todas las clases."
+-- Modules/ProfileManager/GUI.lua:231
+CLM.L["Select character to be marked as main for alt-main linking."] = "Seleccione el carácter que se marcará como principal para la vinculación alt-main."
+-- Modules/BiddingManager/GUI.lua:154
+CLM.L["Select custom button mode"] = "Seleccione el modo de botón personalizado"
+-- Modules/Logger/Logger.lua:20
+CLM.L["Select logging level for troubleshooting"] = "Seleccione el nivel de registro para la solución de problemas"
+-- Global/GlobalConfigs.lua:96
+CLM.L["Select loot rarity for the annoucement to raid."] = "Seleccione la rareza del botín para el anuncio de incursión."
+-- Modules/LootQueueManager/LootQueueManager.lua:78
+CLM.L["Select loot rarity for the tracking unauctioned loot."] = "Seleccione la rareza del botín para el seguimiento del botín que no sea de subasta."
+-- Modules/ProfileManager/GUI.lua:230
+CLM.L["Select main"] = "Seleccionar Main"
+-- Modules/PointManager/GUI.lua:117
+-- Modules/LootManager/GUI.lua:125
+CLM.L["Select player"] = "Seleccionar un jugador"
+-- Modules/ProfileManager/GUI.lua:272
+CLM.L["Select roster to add profiles to."] = "Seleccione el roster al que agregar perfiles."
+-- Modules/RaidManager/GUI.lua:319
+CLM.L["Select roster to create raid for."] = "Seleccione el roster para crear la raid."
+-- Modules/RaidManager/GUI.lua:318
+-- Modules/RosterManager/GUI.lua:500
+-- Modules/PointManager/GUI.lua:108
+-- Modules/ProfileManager/GUI.lua:271
+-- Modules/LootManager/GUI.lua:116
+CLM.L["Select roster"] = "Seleccionar el roster"
+-- Modules/RosterManager/Options.lua:679
+CLM.L["Select weekly reset timezone. EU: Wed 07:00 GMT or US: Tue 15:00 GMT"] = "Seleccione la zona horaria de restablecimiento semanal. UE: miércoles 07:00 GMT o EE. UU.: martes 15:00 GMT"
+-- Modules/AutoAwardManager/EncounterIDs.lua:255
+CLM.L["Serpentshrine Cavern"] = "Caverna Santuario Serpiente"
+-- Modules/LedgerManager/GUI.lua:376
+CLM.L["Set %s DKP to %s players for %s in <%s>"] = "Establecer %s DKP en %s jugadores para %s en <%s>"
+-- Migration.lua:359
+CLM.L["Set DKP for %s players for team to %s"] = "Establecer DKP para %s jugadores por equipo en %s"
+-- Modules/RaidManager/GUI.lua:342
+CLM.L["Set raid name"] = "Establecer nombre de raid"
+-- Modules/AutoAwardManager/EncounterIDs.lua:88
+CLM.L["Shade of Akama"] = "Sombra de Akama"
+-- Modules/AutoAwardManager/EncounterIDs.lua:68
+CLM.L["Shade of Aran"] = "Sombra de Aran"
+-- .:indirectly
+CLM.L["Shaman"] = "Chaman"
+-- Modules/AutoAwardManager/EncounterIDs.lua:9
+CLM.L["Shazzrah"] = "Shazzrah"
+-- Modules/RosterManager/Roster.lua:760
+-- Modules/RosterManager/Roster.lua:792
+CLM.L["Shield"] = "Escudo"
+-- Modules/RosterManager/Roster.lua:743
+-- Modules/RosterManager/Roster.lua:775
+CLM.L["Shirt"] = "Camisa"
+-- Modules/RosterManager/Roster.lua:742
+-- Modules/RosterManager/Roster.lua:774
+CLM.L["Shoulder"] = "Hombro"
+-- Modules/AutoAwardManager/EncounterIDs.lua:23
+CLM.L["Silithid Royalty"] = "Bug Trio"
+-- Modules/RosterManager/Options.lua:740
+CLM.L["Single-Priced (static) or Ascending (in range of min-max) item value."] = "Valor de artículo de precio único (estático) o ascendente (en el rango de mínimo-máximo)."
+-- Modules/RosterManager/Roster.lua:698
+CLM.L["Single-Priced"] = "Precio único"
+-- Migration.lua:160
+CLM.L["Skipping %s"] = "Saltando %s"
+-- Migration.lua:236
+CLM.L["Skipping CommunityDKP"] = "Ignorar CommunityDKP"
+-- Global/GlobalSlashCommands.lua:100
+CLM.L["Spec guild request"] = "Solicitud de especificaciones de la Hermandad"
+-- Modules/AuctionManager/GUI.lua:235
+-- Modules/RosterManager/GUI.lua:485
+-- Modules/ProfileManager/GUI.lua:382
+CLM.L["Spec"] = "Especificación"
+-- Modules/RaidManager/RaidManager.lua:805
+CLM.L["Stale"] = "Caducado"
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:157
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:167
+CLM.L["Standby %s has been sent"] = "Se ha enviado %s en espera"
+-- Modules/PointManager/PointManager.lua:414
+CLM.L["Standby Bonus"] = "Bono de espera"
+-- Modules/RaidManager/GUI.lua:428
+-- Modules/RosterManager/GUI.lua:128
+CLM.L["Standby"] = "En espera"
+-- MinimapIcon.lua:27
+-- Modules/RosterManager/GUI.lua:739
+-- Modules/LootManager/GUI.lua:416
+CLM.L["Standings"] = "Posiciones"
+-- Modules/RaidManager/GUI.lua:124
+CLM.L["Start selected raid"] = "Iniciar raid seleccionada"
+-- Modules/AuctionManager/GUI.lua:433
+CLM.L["Start"] = "Comienzo"
+-- Modules/LedgerManager/GUI.lua:415
+CLM.L["Started raid %s"] = "Raid iniciada %s"
+-- Modules/RosterManager/GUI.lua:648
+CLM.L["Statistics:"] = "Estadísticas:"
+-- Modules/RaidManager/GUI.lua:388
+CLM.L["Status"] = "Estado"
+-- Modules/AuctionManager/GUI.lua:433
+CLM.L["Stop"] = "Detener"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:65
+CLM.L["Store bids"] = "Tienda de ofertas"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:66
+CLM.L["Store finished auction bids information."] = "Almacenar información de ofertas de subastas terminadas."
+-- Modules/AutoAwardManager/EncounterIDs.lua:10
+CLM.L["Sulfuron Harbinger"] = "Sulfuron Presagista"
+-- Modules/AutoAwardManager/EncounterIDs.lua:315
+CLM.L["Sunwell Plateau"] = "Meseta de La Fuente del Sol"
+-- Modules/AuctionManager/AuctionManager.lua:121
+CLM.L["Suppress incoming whispers"] = "Suprimir susurro entrante"
+-- Modules/AuctionManager/AuctionManager.lua:130
+CLM.L["Suppress outgoing whispers"] = "Suprimir los susurros salientes"
+-- Modules/Changelog/GUI.lua:81
+CLM.L["Suppresses changelog display until new version is released"] = "Suprime la visualización del registro de cambios hasta que se lanza una nueva versión"
+-- Modules/AutoAwardManager/EncounterIDs.lua:87
+CLM.L["Supremus"] = "Supremus"
+-- MinimapIcon.lua:136
+CLM.L["Sync ongoing"] = "Sincronización en curso"
+-- Modules/RosterManager/Options.lua:417
+CLM.L["TBC"] = "TBC"
+-- Modules/RosterManager/Roster.lua:747
+-- Modules/RosterManager/Roster.lua:779
+CLM.L["Tabard"] = "Tabardo"
+-- Modules/RosterManager/Options.lua:784
+-- Modules/LedgerManager/GUI.lua:176
+CLM.L["Tax"] = "Tasa"
+-- Modules/AutoAwardManager/EncounterIDs.lua:267
+CLM.L["Tempest Keep"] = "El Castillo de la Tempestad"
+-- Modules/AutoAwardManager/EncounterIDs.lua:156
+CLM.L["Temple of Ahn'Qiraj"] = "Templo de Ahn'Qiraj"
+-- Modules/AutoAwardManager/EncounterIDs.lua:67
+CLM.L["Terestian Illhoof"] = "Terestian Pezuña Enferma"
+-- Modules/AutoAwardManager/EncounterIDs.lua:89
+CLM.L["Teron Gorefiend"] = "Teron Sanguino"
+-- Modules/AutoAwardManager/EncounterIDs.lua:37
+CLM.L["Thaddius"] = "Thaddius"
+-- Modules/AutoAwardManager/EncounterIDs.lua:66
+CLM.L["The Curator"] = "Curator"
+-- Modules/AutoAwardManager/EncounterIDs.lua:43
+CLM.L["The Four Horsemen"] = "Cofre de los cuatro jinetes"
+-- Modules/AutoAwardManager/EncounterIDs.lua:93
+CLM.L["The Illidari Council"] = "El Consejo Illidari"
+-- Modules/AutoAwardManager/EncounterIDs.lua:77
+CLM.L["The Lurker Below"] = "El Rondador de abajo"
+-- Modules/AutoAwardManager/EncounterIDs.lua:22
+CLM.L["The Prophet Skeram"] = "El Profeta Skeram"
+-- Modules/RosterManager/Roster.lua:766
+-- Modules/RosterManager/Roster.lua:798
+CLM.L["Thrown"] = "Arma arrojadiza"
+-- Modules/LedgerManager/GUI.lua:512
+CLM.L["Time Travel"] = "Viaje en el tiempo"
+-- MinimapIcon.lua:146
+CLM.L["Time Traveling"] = "Viajar en el tiempo"
+-- Modules/RosterManager/Options.lua:801
+CLM.L["Time in seconds by which auction will be extended if bid is received during last 10 seconds."] = "Tiempo en segundos por el cual se extenderá la subasta si se recibe una oferta durante los últimos 10 segundos."
+-- Modules/AuctionManager/GUI.lua:407
+CLM.L["Time settings"] = "Ajustes de hora"
+-- Modules/LedgerManager/GUI.lua:53
+CLM.L["Time"] = "Hora"
+-- Modules/LedgerManager/GUI.lua:550
+CLM.L["Timetravel"] = "Viaje en el tiempo"
+-- Modules/AuctionHistoryManager/GUI.lua:279
+CLM.L["Toggle Auction History window display"] = "Alternar la visualización de la ventana Historial de subastas"
+-- Modules/AuctionManager/GUI.lua:721
+CLM.L["Toggle Auctioning window display"] = "Alternar la visualización de la ventana de Subastas"
+-- Modules/BiddingManager/BiddingManager.lua:65
+CLM.L["Toggle Bidding auto-open"] = "Alternar ofertas de apertura automática"
+-- Modules/BiddingManager/GUI.lua:503
+CLM.L["Toggle Bidding window display"] = "Alternar la visualización de la ventana de ofertas"
+-- Modules/LootQueueManager/GUI.lua:268
+CLM.L["Toggle Loot Queue window display"] = "Alternar la visualización de la ventana Loot Queue"
+-- Modules/ProfileManager/GUI.lua:506
+CLM.L["Toggle Profiles window display"] = "Alternar la visualización de la ventana Perfiles"
+-- Modules/RaidManager/GUI.lua:549
+CLM.L["Toggle Raid Manager window display"] = "Alternar la visualización de la ventana del Administrador de raid"
+-- Modules/LedgerManager/GUI.lua:676
+CLM.L["Toggle all ledger events audit window"] = "Alternar la ventana de auditoría de todos los eventos del libro mayor"
+-- Modules/BiddingManager/BiddingManager.lua:66
+CLM.L["Toggle auto open and auto close on auction start and stop"] = "Alternar entre abrir y cerrar automáticamente al iniciar y detener la subasta"
+-- Modules/Changelog/GUI.lua:50
+-- Modules/Changelog/GUI.lua:161
+CLM.L["Toggle changelog window display"] = "Alternar la visualización de la ventana de registro de cambios"
+-- Modules/Changelog/GUI.lua:49
+CLM.L["Toggle changelog"] = "Alternar registro de cambios"
+-- Modules/LootManager/GUI.lua:417
+CLM.L["Toggle loot window display"] = "Alternar la visualización de la ventana de botín"
+-- Modules/PointManager/GUI.lua:357
+CLM.L["Toggle point history window display"] = "Alternar la visualización de la ventana del historial de puntos"
+-- Modules/RosterManager/GUI.lua:873
+CLM.L["Toggle standings window display"] = "Alternar la visualización de la ventana de clasificación"
+-- Global/GlobalConfigs.lua:47
+CLM.L["Toggles alerts display when receiving DKP or loot."] = "Alterna la visualización de alertas al recibir DKP o botín."
+-- Global/GlobalConfigs.lua:78
+CLM.L["Toggles loot announcement to raid"] = "Cambia el anuncio de botín a la raid"
+-- Modules/AuctionManager/AuctionManager.lua:81
+CLM.L["Toggles loot award announcement to guild"] = "Cambia el anuncio del premio de botín a la Hermandad"
+-- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:75
+CLM.L["Toggles posting bids in selected channel after auction has ended."] = "Alterna la publicación de ofertas en el canal seleccionado después de que finaliza la subasta."
+-- Modules/RosterManager/GUI.lua:651
+CLM.L["Total blocked"] = "Total bloqueado"
+-- Modules/RosterManager/GUI.lua:652
+CLM.L["Total decayed"] = "Total decaído"
+-- Modules/RosterManager/GUI.lua:650
+CLM.L["Total received"] = "Total recibido"
+-- Modules/RosterManager/GUI.lua:649
+CLM.L["Total spent"] = "Total gastado"
+-- Modules/LootQueueManager/LootQueueManager.lua:77
+CLM.L["Tracked loot rarity"] = "Rareza del botín rastreado"
+-- Modules/RosterManager/Roster.lua:754
+-- Modules/RosterManager/Roster.lua:786
+CLM.L["Trinket"] = "Trinket"
+-- Modules/LedgerManager/GUI.lua:38
+CLM.L["True"] = "Verdad"
+-- Modules/AutoAwardManager/EncounterIDs.lua:28
+CLM.L["Twin Emperors"] = "Emperadores Gemelos"
+-- Modules/RosterManager/Roster.lua:759
+-- Modules/RosterManager/Roster.lua:791
+CLM.L["Two-Hand"] = "Dos manos"
+-- Modules/RosterManager/Options.lua:732
+CLM.L["Type of auction used: Open, Anonymous Open, Sealed, Vickrey (Sealed with second-highest pay price)."] = "Tipo de subasta utilizada: Abierta, Anónima Abierta, Sellada, Vickrey (Sellada con el segundo precio de pago más alto)."
+-- Modules/LedgerManager/GUI.lua:54
+CLM.L["Type"] = "Tipo"
+-- Migration.lua:47
+CLM.L["Unable to execute migration. Entries already exist."] = "No se puede ejecutar la migración. Las entradas ya existen. "
+-- Modules/LootQueueManager/LootQueueManager.lua:84
+-- Global/GlobalConfigs.lua:102
+CLM.L["Uncommon"] = "Poco común"
+-- Modules/PointManager/PointManager.lua:415
+CLM.L["Unexcused absence"] = "Ausencia sin excusa"
+-- Global/GlobalSlashCommands.lua:195
+CLM.L["Unknown roster %s"] = "Roster desconocida %s"
+-- MinimapIcon.lua:138
+CLM.L["Unknown sync state"] = "Estado de sincronización desconocido"
+-- Modules/BiddingManager/BiddingManager.lua:253
+-- Modules/BiddingManager/BiddingManager.lua:254
+-- Modules/RaidManager/GUI.lua:414
+-- Modules/RaidManager/GUI.lua:509
+-- Modules/ProfileManager/Profile.lua:27
+-- Modules/LootManager/GUI.lua:181
+-- Modules/LedgerManager/GUI.lua:194
+CLM.L["Unknown"] = "Desconocido"
+-- Global/GlobalSlashCommands.lua:44
+CLM.L["Unlink Alt"] = "Desvincular Alter"
+-- Migration.lua:125
+CLM.L["UpdatePoints(): Empty targets list"] = "UpdatePoints(): lista de objetivos vacíos"
+-- Modules/LedgerManager/GUI.lua:422
+CLM.L["Updated raid <%s> %s joined, %s left, %s benched, %s removed"] = "Raid actualizada <%s> %s se unió, %s se fue, %s se quedó en el banquillo, %s se eliminó"
+-- Modules/AutoAwardManager/EncounterIDs.lua:15
+CLM.L["Vaelastrasz the Corrupt"] = "Vaelastrasz el Corrupto"
+-- Modules/AuctionManager/GUI.lua:375
+CLM.L["Value ranges"] = "Rangos de valores"
+-- Modules/BiddingManager/GUI.lua:163
+CLM.L["Value to use in custom mode"] = "Valor para usar en modo personalizado"
+-- Modules/BiddingManager/GUI.lua:246
+CLM.L["Value you want to bid. Press Enter or click Okay button to accept."] = "Valor que desea ofertar. Presione Entrar o haga clic en el botón OK para aceptar. ."
+-- Modules/PointManager/GUI.lua:96
+-- Modules/LootManager/GUI.lua:94
+-- Modules/LootManager/GUI.lua:101
+CLM.L["Value"] = "Valor"
+-- Modules/Logger/Logger.lua:28
+CLM.L["Verbose"] = "Detallado"
+-- Global/GlobalSlashCommands.lua:90
+CLM.L["Version check in guild"] = "Comprobación de versión en la Hermandad"
+-- Modules/ProfileManager/GUI.lua:385
+CLM.L["Version"] = "Versión"
+-- Modules/RosterManager/Roster.lua:678
+CLM.L["Vickrey"] = "Vickrey"
+-- Modules/AutoAwardManager/EncounterIDs.lua:26
+CLM.L["Viscidus"] = "Viscidus"
+-- Modules/AutoAwardManager/EncounterIDs.lua:83
+CLM.L["Void Reaver"] = "Atracador del vacío"
+-- Modules/RosterManager/Roster.lua:750
+-- Modules/RosterManager/Roster.lua:782
+CLM.L["Waist"] = "Cintura"
+-- .:indirectly
+CLM.L["Warlock"] = "Brujo"
+-- .:indirectly
+CLM.L["Warrior"] = "Guerrero"
+-- Modules/LedgerManager/GUI.lua:149
+CLM.L["Weekly DKP cap"] = "Límite semanal de DKP"
+-- Modules/RosterManager/Options.lua:687
+CLM.L["Weekly cap"] = "Límite semanal"
+-- Modules/RosterManager/GUI.lua:645
+CLM.L["Weekly gains"] = "Ganancias semanales"
+-- Modules/RosterManager/Options.lua:678
+CLM.L["Weekly reset timezone"] = "Zona horaria de restablecimiento semanal"
+-- Modules/LedgerManager/GUI.lua:152
+CLM.L["Weekly reset"] = "Reinicio semanal"
+-- Global/GlobalConfigs.lua:87
+CLM.L["When enabled, this will make loot announcement display only if you're Master Looter or Raid Leader (if there is no Master Looter)."] = "Cuando está habilitado, esto hará que se muestre el anuncio del botín solo si eres Master Looter o Raid Leader (si no hay Master Looter)."
+-- Global/GlobalConfigs.lua:64
+CLM.L["Wipe events"] = "Borrar eventos"
+-- Modules/Logger/Logger.lua:36
+CLM.L["Wipe"] = "Borrar"
+-- Global/GlobalConfigs.lua:65
+CLM.L["Wipes all events from memory. This will trigger resyncing from other users."] = "Borra todos los eventos de la memoria. Esto activará la resincronización de otros usuarios."
+-- Modules/Logger/Logger.lua:37
+CLM.L["Wipes the log history"] = "Borra el historial de registro"
+-- Global/GlobalConfigs.lua:55
+CLM.L["WoW DKP Bot Integration"] = "Integración WoW DKP Bot"
+-- Modules/RosterManager/Roster.lua:748
+-- Modules/RosterManager/Roster.lua:780
+CLM.L["Wrist"] = "Muñeca"
+-- Utils.lua:447
+CLM.L["Yes"] = "Sí"
+-- Modules/RaidManager/RaidManager.lua:363
+CLM.L["You are already in an active raid. Leave or finish it before creating new one."] = "Ya estás en una raid activa. Déjala o termínala antes de crear una nueva. "
+-- Modules/AuctionManager/AuctionManager.lua:170
+CLM.L["You are not allowed to auction items"] = "No tienes permitido subastar artículos."
+-- Modules/RaidManager/RaidManager.lua:495
+-- Modules/RaidManager/RaidManager.lua:529
+CLM.L["You are not allowed to control raid."] = "No tienes permitido controlar la raid."
+-- Modules/RaidManager/RaidManager.lua:359
+CLM.L["You are not allowed to create raids."] = "No tienes permitido crear raids."
+-- Modules/RaidManager/RaidManager.lua:466
+CLM.L["You are not allowed to join raid."] = "No tienes permitido unirte a la raid."
+-- Modules/RaidManager/RaidManager.lua:381
+-- Modules/RaidManager/RaidManager.lua:437
+CLM.L["You are not allowed to start raid."] = "No se le permite iniciar la raid."
+-- Modules/RaidManager/RaidManager.lua:449
+CLM.L["You are not in an active raid."] = "No estás en una raid activa."
+-- Modules/RaidManager/RaidManager.lua:394
+CLM.L["You are not in the raid."] = "No estás en la raid."
+-- Modules/RosterManager/GUI.lua:574
+-- Modules/RosterManager/GUI.lua:583
+CLM.L["You can %s max %d players from standby at the same time to a %s raid."] = "Puedes %s como máximo %d jugadores desde el modo de espera al mismo tiempo a una raid de %s."
+-- Modules/RosterManager/GUI.lua:531
+-- Modules/RosterManager/GUI.lua:540
+CLM.L["You can %s max %d players to standby at the same time to a %s raid."] = "Puede %s como máximo %d jugadores para estar en espera al mismo tiempo en una raid de %s."
+-- Modules/RaidManager/RaidManager.lua:499
+-- Modules/RaidManager/RaidManager.lua:533
+CLM.L["You can only add players to standby of a progressing raid."] = "Solo puedes agregar jugadores al modo de espera de una raid en progreso."
+-- Modules/RosterManager/GUI.lua:522
+CLM.L["You can only bench players from same roster as the raid (%s)."] = "Solo puedes enviar al banquillo a jugadores del mismo roster que la raid (%s)."
+-- Modules/RaidManager/RaidManager.lua:441
+CLM.L["You can only end an active raid."] = "Solo puedes finalizar una raid activa."
+-- Modules/RaidManager/RaidManager.lua:470
+CLM.L["You can only join an active raid."] = "Solo puedes unirte a una raid activa."
+-- Modules/RaidManager/RaidManager.lua:474
+CLM.L["You can only join different raid than your current one."] = "Solo puedes unirte a una raid diferente a la actual."
+-- Modules/RosterManager/GUI.lua:565
+CLM.L["You can only remove from bench players from same roster as the raid (%s)."] = "Solo puedes eliminar del banquillo a jugadores del mismo roster que el raid (%s)."
+-- Modules/RaidManager/RaidManager.lua:385
+CLM.L["You can only start a freshly created raid."] = "Solo puedes iniciar una raid recién creada."
+-- Modules/RosterManager/GUI.lua:615
+CLM.L["You can remove max %d players from roster at the same time."] = "Puede eliminar un máximo de %d jugadores del la roster al mismo tiempo."
+-- Debug.lua:182
+CLM.L["You have just received Kill Command from %s. All Ledger data was wiped. Please reload the UI."] = "Acabas de recibir Kill Command de %s. Se borraron todos los datos del libro mayor. Vuelva a cargar la interfaz de usuario. "
+-- Modules/BiddingManager/BiddingManager.lua:254
+CLM.L["Your bid (%s) was denied: |cffcc0000%s|r"] = "Su oferta (%s) fue denegada: |cffcc0000%s|r"
+-- Modules/BiddingManager/BiddingManager.lua:240
+CLM.L["Your bid (%s) was |cff00cc00accepted|r"] = "Su oferta (%s) fue |cff00cc00aceptada|r"
+-- Modules/LedgerManager/GUI.lua:104
+CLM.L["Zero-Sum Bank Inflation"] = "Inflación bancaria de suma cero"
+-- Modules/RosterManager/Options.lua:747
+-- Modules/LedgerManager/GUI.lua:101
+CLM.L["Zero-Sum Bank"] = "banco de suma cero"
+-- Modules/RosterManager/Options.lua:754
+CLM.L["Zero-Sum Inflation Value"] = "Valor de inflación de suma cero"
+-- Modules/PointManager/PointManager.lua:418
+CLM.L["Zero-Sum award"] = "premio de suma cero"
+-- Modules/AutoAwardManager/EncounterIDs.lua:303
+CLM.L["Zul'Aman"] = "Zul'Aman"
+-- Modules/AutoAwardManager/EncounterIDs.lua:192
+CLM.L["Zul'Gurub"] = "Zul'Gurub"
+-- Modules/AutoAwardManager/EncounterIDs.lua:105
+CLM.L["Zul'jin"] = "Zul'jin"
+-- Modules/LedgerManager/GUI.lua:270
+CLM.L["[All Roster Configs]: "] = "[Todas las configuraciones del roster]: "
+-- Modules/LedgerManager/GUI.lua:283
+CLM.L["[All Roster Default Slot Values]: "] = "[Todos los valores de ranura predeterminados del roster]: "
+-- Modules/LedgerManager/GUI.lua:240
+-- Modules/LedgerManager/GUI.lua:247
+CLM.L["[Alt-Main Link]: "] = "[Alt-Main Enlace principal]: "
+-- Modules/LedgerManager/GUI.lua:254
+CLM.L["[Create Roster]: "] = "[Crear Roster]: "
+-- Modules/LedgerManager/GUI.lua:260
+CLM.L["[Delete Roster]: "] = "[Eliminar Roster]: "
+-- Modules/LedgerManager/GUI.lua:436
+CLM.L["[IGNORE]: Ignoring entry"] = "[IGNORAR]: Ignorar entrada"
+-- Modules/LedgerManager/GUI.lua:396
+CLM.L["[Item Award in Raid]: "] = "[Premio de artículo en raid]:"
+-- Modules/LedgerManager/GUI.lua:386
+CLM.L["[Item Award]: "] = "[Premio del artículo]: "
+-- Modules/LedgerManager/GUI.lua:359
+CLM.L["[Point Award to raid]: "] = "[Premio de puntos a la raid]: "
+-- Modules/LedgerManager/GUI.lua:351
+CLM.L["[Point Award to roster]: "] = "[Premio de puntos al roster]: "
+-- Modules/LedgerManager/GUI.lua:335
+CLM.L["[Point Award]: "] = "[Premio de puntos]: "
+-- Modules/LedgerManager/GUI.lua:367
+CLM.L["[Point Decay for roster]: "] = "[Decaimiento de puntos para el roster]: "
+-- Modules/LedgerManager/GUI.lua:343
+CLM.L["[Point Decay]: "] = "[Punto de caída]: "
+-- Modules/LedgerManager/GUI.lua:375
+CLM.L["[Point Set]: "] = "[Conjunto de puntos]: "
+-- Modules/LedgerManager/GUI.lua:405
+CLM.L["[Raid Create]: "] = "[Raid creada]: "
+-- Modules/LedgerManager/GUI.lua:430
+CLM.L["[Raid Finish]: "] = "[Raid finalizada]: "
+-- Modules/LedgerManager/GUI.lua:414
+CLM.L["[Raid Start]: "] = "[Inicio de la Raid]: "
+-- Modules/LedgerManager/GUI.lua:421
+CLM.L["[Raid Update]: "] = "[Raid actualizada]: "
+-- Modules/LedgerManager/GUI.lua:230
+CLM.L["[Remove Profile]: "] = "[Perfil eliminado]: "
+-- Modules/LedgerManager/GUI.lua:264
+CLM.L["[Rename Roster]: "] = "[Renombrar Roster]: "
+-- Modules/LedgerManager/GUI.lua:327
+CLM.L["[Roster Boss Kill Bonus]: "] = "[Bonificación por matar al jefe del roster]: "
+-- Modules/LedgerManager/GUI.lua:277
+CLM.L["[Roster Config]: "] = "[Configuración del roster]:: "
+-- Modules/LedgerManager/GUI.lua:315
+CLM.L["[Roster Copy]: "] = "[Copia del roster]: "
+-- Modules/LedgerManager/GUI.lua:290
+CLM.L["[Roster Default Slot Value]: "] = "[Valor del Roster por defecto]: "
+-- Modules/LedgerManager/GUI.lua:297
+-- Modules/LedgerManager/GUI.lua:303
+CLM.L["[Roster Item Value Override]: "] = "[Anulación del valor del elemento del roster]: "
+-- Modules/LedgerManager/GUI.lua:307
+CLM.L["[Roster Update Profiles]: "] = "[Actualizar perfiles del roster]: "
+-- Modules/LedgerManager/GUI.lua:222
+CLM.L["[Update Profile]: "] = "[Actulizar el perfil]: "
+-- Modules/LedgerManager/GUI.lua:318
+CLM.L["[config] "] = "[Configuración] "
+-- Modules/LedgerManager/GUI.lua:320
+CLM.L["[item values] "] = "[Valor del artículo] "
+-- Modules/LedgerManager/GUI.lua:321
+CLM.L["[profiles] "] = "Perfiles] "
+-- Modules/LedgerManager/GUI.lua:319
+CLM.L["[slot defaults] "] = "[valores predeterminados de la ranura] "
+-- Global/GlobalChatMessageHandlers.lua:63
+CLM.L["accepted"] = "Aceptado"
+-- Modules/RosterManager/GUI.lua:532
+-- Modules/RosterManager/GUI.lua:541
+CLM.L["add"] = "añadir"
+-- Modules/RosterManager/GUI.lua:117
+CLM.L["all"] = "todo"
+-- Modules/BiddingManager/BiddingManager.lua:238
+-- Modules/BiddingManager/BiddingManager.lua:252
+-- Global/GlobalChatMessageHandlers.lua:50
+CLM.L["cancel"] = "cancelar"
+-- Modules/RosterManager/GUI.lua:541
+-- Modules/RosterManager/GUI.lua:584
+CLM.L["created"] = "creado"
+-- Global/GlobalChatMessageHandlers.lua:63
+CLM.L["denied"] = "denegado"
+-- Modules/LedgerManager/GUI.lua:369
+CLM.L["excluding negatives "] = "excluyendo negativos "
+-- Global/GlobalSlashCommands.lua:73
+CLM.L["level"] = "nivel"
+-- Global/GlobalChatMessageHandlers.lua:52
+CLM.L["pass"] = "pasar"
+-- Modules/RosterManager/GUI.lua:532
+-- Modules/RosterManager/GUI.lua:575
+CLM.L["progressing"] = "progresando"
+-- Global/GlobalSlashCommands.lua:76
+CLM.L["rank"] = "rango"
+-- Modules/RosterManager/GUI.lua:575
+-- Modules/RosterManager/GUI.lua:584
+CLM.L["remove"] = "retirar"
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:158
+CLM.L["request"] = "solicitud"
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:56
+CLM.L["requested"] = "solicitado"
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:168
+CLM.L["revoke"] = "revocar"
+-- Modules/StandbyStagingManager/StandbyStagingManager.lua:86
+CLM.L["revoked"] = "revocado"
+-- Global/GlobalChatMessageHandlers.lua:102
+CLM.L["roster"] = "roster"
+-- Global/GlobalChatMessageHandlers.lua:102
+CLM.L["rosters"] = "rosters"
+-- Modules/RosterManager/GUI.lua:119
+CLM.L["selected"] = "seleccionado"
+-- Global/GlobalSlashCommands.lua:80
+CLM.L["unguilded"] = "Sin Hermandad"
+-- Modules/ProfileInfoManager/ProfileInfoManager.lua:62
+CLM.L["|cffcc0000Your Classic Loot Manager is significantly out of date.|r AddOn communication has been disabled. Version %s is available. Please update as soon as possible."] = "|cffcc0000Tu Classic Loot Manager está significativamente desactualizado.|r La comunicación AddOn ha sido deshabilitada. La versión %s está disponible. Actualice lo antes posible. "
+end

--- a/Locale/esES.lua
+++ b/Locale/esES.lua
@@ -22,6 +22,8 @@ CLM.L[" profile(s)"] = " perfil(es)"
 CLM.L["!bid"] = "!bid"
 -- Global/GlobalChatMessageHandlers.lua:67
 CLM.L["!dkp"] = "!dkp"
+-- Integrations/Exporter.lua:290
+-- Integrations/Exporter.lua:291
 -- Modules/RaidManager/GUI.lua:511
 -- Modules/PointManager/GUI.lua:274
 -- Modules/AuctionHistoryManager/GUI.lua:226
@@ -33,25 +35,25 @@ CLM.L["%d %% DKP decay"] = "%d %% Decalage DKP"
 CLM.L["%d DKP"] = "%d DKP"
 -- Modules/LedgerManager/GUI.lua:447
 CLM.L["%d/%m/%Y %H:%M:%S"] = "%d/%m/%Y %H:%M:%S"
--- Modules/LootManager/LootManager.lua:156
+-- Modules/LootManager/LootManager.lua:157
 CLM.L["%s awarded to %s for %s DKP"] = "%s adjudicado a %s por %s DKP"
--- MinimapIcon.lua:123
+-- MinimapIcon.lua:129
 CLM.L["%s events (%s pending)"] = "%s eventos (%s pendientes)"
--- MinimapIcon.lua:125
+-- MinimapIcon.lua:131
 CLM.L["%s events (0x%x)"] = "%s eventos (0x%x)"
 -- Modules/StandbyStagingManager/StandbyStagingManager.lua:54
 -- Modules/StandbyStagingManager/StandbyStagingManager.lua:84
 CLM.L["%s has %s standby"] = "%s tiene %s en espera"
--- Global/GlobalSlashCommands.lua:210
+-- Global/GlobalSlashCommands.lua:200
 CLM.L["%s is not part of the %s roster"] = "%s no es parte del  %s roster"
--- Global/GlobalSlashCommands.lua:131
+-- Global/GlobalSlashCommands.lua:121
 CLM.L["%s profile exists."] = "%s perfil existente."
--- Global/GlobalSlashCommands.lua:133
+-- Global/GlobalSlashCommands.lua:123
 CLM.L["%s profile missing. Adding."] = "%s falta el perfil. Agregando."
 -- Modules/LedgerManager/GUI.lua:387
 -- Modules/LedgerManager/GUI.lua:397
 CLM.L["%s to %s for %s in <%s>"] = "%s a %s para %s en <%s>"
--- Global/GlobalSlashCommands.lua:139
+-- Global/GlobalSlashCommands.lua:129
 CLM.L["%s was not found in guild."] = "%s no se encontró en la Hermandad."
 -- Modules/PointManager/GUI.lua:322
 -- Modules/PointManager/GUI.lua:322
@@ -128,10 +130,10 @@ CLM.L["Allow players to subscribe to the bench through Raids menu"] = "Permitir 
 -- Modules/RosterManager/Options.lua:711
 -- Modules/LedgerManager/GUI.lua:173
 CLM.L["Allow subscription"] = "Permitir suscripción"
--- Modules/RosterManager/Roster.lua:815
+-- Modules/RosterManager/Roster.lua:817
 CLM.L["Americas"] = "Américas"
--- Modules/RosterManager/Roster.lua:765
--- Modules/RosterManager/Roster.lua:797
+-- Modules/RosterManager/Roster.lua:767
+-- Modules/RosterManager/Roster.lua:799
 CLM.L["Ammo"] = "Munición"
 -- Modules/AutoAwardManager/EncounterIDs.lua:96
 CLM.L["Anetheron"] = "Anetheron"
@@ -143,14 +145,14 @@ CLM.L["Announce loot from corpse to Raid"] = "Anunciar el botín a la raid"
 CLM.L["Announce loot"] = "Anunciar el botín"
 -- Global/GlobalConfigs.lua:95
 CLM.L["Announcement loot rarity"] = "Anuncio de rareza de botín"
--- Modules/RosterManager/Roster.lua:679
+-- Modules/RosterManager/Roster.lua:681
 CLM.L["Anonymous Open"] = "Anónimo abierto"
 -- Modules/RosterManager/Options.lua:800
 CLM.L["Anti-snipe time"] = "Tiempo anti-snipe"
 -- Modules/AuctionManager/AuctionManager.lua:244
 CLM.L["Anti-snipe time: %s."] = "Tiempo anti-snipe: %s."
 -- Modules/RaidManager/GUI.lua:201
--- Modules/AuctionManager/GUI.lua:423
+-- Modules/AuctionManager/GUI.lua:372
 -- Modules/LedgerManager/GUI.lua:110
 CLM.L["Anti-snipe"] = "Anti-snipe"
 -- Modules/AutoAwardManager/EncounterIDs.lua:31
@@ -161,11 +163,13 @@ CLM.L["Any"] = "Todo"
 CLM.L["Applies all changes and exits sandbox mode"] = "Aplica todos los cambios y salir del modo sandbox"
 -- Modules/LedgerManager/GUI.lua:484
 CLM.L["Apply changes"] = "Aplicar los cambios"
+-- Integrations/GUI.lua:139
+CLM.L["April"] = "Abril"
 -- Modules/AutoAwardManager/EncounterIDs.lua:99
 CLM.L["Archimonde"] = "Archimonde"
--- Modules/AuctionManager/GUI.lua:487
+-- Modules/AuctionManager/GUI.lua:436
 CLM.L["Are you sure, you want to award %s to %s for %s DKP?"] = "¿Está seguro de que desea otorgar %s a %s por %s DKP?"
--- Modules/RosterManager/Roster.lua:699
+-- Modules/RosterManager/Roster.lua:701
 CLM.L["Ascending"] = "Ascendente"
 -- Modules/ProfileManager/GUI.lua:444
 CLM.L["Assistant"] = "Asistente"
@@ -180,7 +184,7 @@ CLM.L["Auction End Countdown"] = "Cuenta regresiva para el final de la subasta"
 -- MinimapIcon.lua:51
 -- Modules/AuctionHistoryManager/GUI.lua:195
 CLM.L["Auction History"] = "Historial de subastas"
--- Modules/AuctionManager/GUI.lua:447
+-- Modules/AuctionManager/GUI.lua:396
 CLM.L["Auction Results"] = "Resultados de la subasta"
 -- Global/GlobalConfigs.lua:126
 CLM.L["Auction Start/End"] = "Subasta Inicio/Terminación"
@@ -191,16 +195,16 @@ CLM.L["Auction Time"] = "Tiempo de subasta"
 CLM.L["Auction Type"] = "Tipo de subasta"
 -- Modules/AuctionManager/AuctionManager.lua:312
 CLM.L["Auction complete"] = "Subasta completa"
--- Modules/BiddingManager/BiddingManager.lua:219
+-- Modules/BiddingManager/BiddingManager.lua:209
 CLM.L["Auction finished"] = "Subasta finalizada"
 -- Modules/LootQueueManager/GUI.lua:60
 CLM.L["Auction item"] = "Artículo de subasta"
 -- Modules/RosterManager/Options.lua:793
 CLM.L["Auction length in seconds."] = "Duración de la subasta en segundos."
--- Modules/AuctionManager/GUI.lua:413
+-- Modules/AuctionManager/GUI.lua:362
 -- Modules/RosterManager/Options.lua:792
 CLM.L["Auction length"] = "Duración de la subasta."
--- Modules/BiddingManager/BiddingManager.lua:206
+-- Modules/BiddingManager/BiddingManager.lua:196
 CLM.L["Auction of "] = "Subasta de"
 -- Modules/AuctionManager/AuctionManager.lua:229
 CLM.L["Auction of %s"] = "Subasta de %s"
@@ -217,11 +221,13 @@ CLM.L["Auctioning - Chat Commands"] = "Subastas: comandos de chat"
 -- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:61
 CLM.L["Auctioning - History"] = "Subastas - Historia"
 -- MinimapIcon.lua:46
--- Modules/AuctionManager/GUI.lua:587
+-- Modules/AuctionManager/GUI.lua:536
 -- Modules/AuctionManager/AuctionManager.lua:76
 CLM.L["Auctioning"] = "Subasta"
 -- MinimapIcon.lua:74
 CLM.L["Audit"] = "Auditoría"
+-- Integrations/GUI.lua:143
+CLM.L["August"] = "Agosto"
 -- Modules/LedgerManager/GUI.lua:56
 CLM.L["Author"] = "Autor"
 -- Modules/RaidManager/GUI.lua:297
@@ -240,16 +246,16 @@ CLM.L["Award DKP to selected players or everyone if none selected."] = "Otorgue 
 CLM.L["Award DKP value"] = "Asignar valor DKP"
 -- Global/GlobalSlashCommands.lua:26
 CLM.L["Award item without auctioning it."] = "Adjudicar artículo sin subastarlo."
--- Modules/AuctionManager/GUI.lua:452
+-- Modules/AuctionManager/GUI.lua:401
 -- Global/GlobalSlashCommands.lua:25
 CLM.L["Award item"] = "Asignar objeto"
 -- Modules/RosterManager/Options.lua:655
 CLM.L["Award points only to online players"] = "Otorga puntos solo a jugadores en línea"
 -- Modules/RosterManager/Options.lua:664
 CLM.L["Award points only to players in same zone"] = "Otorga puntos solo a jugadores en la misma zona"
--- Modules/AuctionManager/GUI.lua:458
+-- Modules/AuctionManager/GUI.lua:407
 CLM.L["Award value"] = "Valor asignado"
--- Modules/AuctionManager/GUI.lua:467
+-- Modules/AuctionManager/GUI.lua:416
 -- Modules/RosterManager/GUI.lua:262
 CLM.L["Award"] = "Recompensa"
 -- Modules/LedgerManager/GUI.lua:360
@@ -261,31 +267,41 @@ CLM.L["Awarded %s DKP to all players for %s in <%s>"] = "Otorgó %s DKP a todos 
 -- Modules/PointManager/GUI.lua:97
 -- Modules/LootManager/GUI.lua:187
 CLM.L["Awarded by"] = "Otorgado por"
--- Modules/AuctionManager/GUI.lua:261
--- Modules/AuctionManager/GUI.lua:659
+-- Modules/AuctionManager/GUI.lua:210
+-- Modules/AuctionManager/GUI.lua:608
 CLM.L["Awarding to %s for %d."] = "Otorgando a %s por %d."
 -- Modules/AutoAwardManager/EncounterIDs.lua:60
 CLM.L["Ayamiss the Hunter"] = "Ayamiss el Cazador"
 -- Modules/AutoAwardManager/EncounterIDs.lua:98
 CLM.L["Azgalor"] = "Azgalor"
--- Modules/RosterManager/Roster.lua:744
--- Modules/RosterManager/Roster.lua:776
+-- Modules/RosterManager/Roster.lua:746
+-- Modules/RosterManager/Roster.lua:778
 CLM.L["Back"] = "Atras"
--- Modules/RosterManager/Roster.lua:764
--- Modules/RosterManager/Roster.lua:796
+-- Modules/RosterManager/Roster.lua:766
+-- Modules/RosterManager/Roster.lua:798
 CLM.L["Bag"] = "Bolsa"
 -- Modules/AutoAwardManager/EncounterIDs.lua:8
 CLM.L["Baron Geddon"] = "Baron Geddon"
 -- Modules/RosterManager/Options.lua:318
 CLM.L["Base value for Static-Priced auction. Minimum value for Ascending auction. Set to 0 to ignore."] = "Valor base para subasta de precio estático. Valor mínimo para subasta Ascendente. Establecer en 0 para ignorar."
 -- Modules/BiddingManager/GUI.lua:262
--- Modules/AuctionManager/GUI.lua:381
+-- Modules/AuctionManager/GUI.lua:330
 -- Modules/RosterManager/Options.lua:373
 CLM.L["Base"] = "Base"
 -- Modules/BiddingManager/GUI.lua:433
 CLM.L["Base: %d "] = "Base: %d "
 -- Modules/AutoAwardManager/EncounterIDs.lua:24
 CLM.L["Battleguard Sartura"] = "Guardia de batalla Sartura"
+-- Integrations/GUI.lua:309
+-- Integrations/GUI.lua:316
+-- Integrations/GUI.lua:323
+CLM.L["Begin %d days ago, finish today."] = "Empezar hace %d días, finalizar hoy."
+-- Integrations/GUI.lua:242
+CLM.L["Begin Day"] = "Día de inicio"
+-- Integrations/GUI.lua:253
+CLM.L["Begin Month"] = "Mes de inicio"
+-- Integrations/GUI.lua:264
+CLM.L["Begin Year"] = "Año de inicio"
 -- Modules/RosterManager/Options.lua:705
 CLM.L["Bench"] = "Banquillo"
 -- Alerts/Alerts.lua:24
@@ -309,7 +325,7 @@ CLM.L["Bid your current DKP (%s)."] = "Oferte su DKP actual (%s)."
 -- Modules/BiddingManager/GUI.lua:95
 CLM.L["Bid your preset value."] = "Oferte su valor preestablecido."
 -- Modules/BiddingManager/GUI.lua:254
--- Modules/AuctionManager/GUI.lua:236
+-- Modules/AuctionManager/GUI.lua:185
 CLM.L["Bid"] = "Oferta de compra"
 -- Modules/AuctionManager/AuctionManager.lua:661
 CLM.L["Bidding over current standings not allowed"] = "No se permite pujar sobre la clasificación actual"
@@ -364,15 +380,15 @@ CLM.L["Channel for posting bids."] = "Canal de publicación de ofertas."
 CLM.L["Chat Commands"] = "Comandos de chat"
 -- Modules/AutoAwardManager/EncounterIDs.lua:70
 CLM.L["Chess Event"] = "Chess Event"
--- Modules/RosterManager/Roster.lua:746
--- Modules/RosterManager/Roster.lua:778
+-- Modules/RosterManager/Roster.lua:748
+-- Modules/RosterManager/Roster.lua:780
 CLM.L["Chest (robes)"] = "Pecho (túnicas)"
--- Modules/RosterManager/Roster.lua:745
--- Modules/RosterManager/Roster.lua:777
+-- Modules/RosterManager/Roster.lua:747
+-- Modules/RosterManager/Roster.lua:779
 CLM.L["Chest"] = "Pecho"
 -- Modules/AutoAwardManager/EncounterIDs.lua:20
 CLM.L["Chromaggus"] = "Chromaggus"
--- Modules/AuctionManager/GUI.lua:228
+-- Modules/AuctionManager/GUI.lua:177
 -- Modules/RosterManager/GUI.lua:478
 -- Modules/ProfileManager/GUI.lua:375
 CLM.L["Class"] = "Clase"
@@ -385,12 +401,15 @@ CLM.L["Classic"] = "Classic"
 CLM.L["Clear all classes."] = "Borrar todas las clases."
 -- Modules/ProfileManager/GUI.lua:256
 CLM.L["Clear mains"] = "Borrar mains"
+-- Integrations/GUI.lua:467
+CLM.L["Clear output"] = "Borrar salida"
 -- Modules/ProfileManager/GUI.lua:257
 CLM.L["Clears selected profiles mains."] = "Borra los perfiles (mains) seleccionados."
 -- Modules/LootQueueManager/LootQueueManager.lua:83
 -- Global/GlobalConfigs.lua:101
 CLM.L["Common"] = "Común"
--- MinimapIcon.lua:80
+-- MinimapIcon.lua:86
+-- Integrations/GUI.lua:19
 -- Modules/RaidManager/GUI.lua:435
 CLM.L["Configuration"] = "Configuración"
 -- Modules/RosterManager/Options.lua:526
@@ -417,7 +436,7 @@ CLM.L["Create"] = "Crear"
 CLM.L["Created"] = "Creada"
 -- Modules/RosterManager/Options.lua:833
 CLM.L["Creates new roster with default configuration"] = "Crea un nuevo roster con la configuración predeterminada"
--- Modules/AuctionManager/GUI.lua:240
+-- Modules/AuctionManager/GUI.lua:189
 CLM.L["Current"] = "Actual"
 -- Modules/RaidManager/GUI.lua:522
 CLM.L["Currently in raid: "] = "Actualmente en raid: "
@@ -435,10 +454,12 @@ CLM.L["DKP % that will be decayed."] = "DKP % que se decaerá."
 CLM.L["DKP & Loot alerts"] = "Alertas de botín y DKP"
 -- Modules/RosterManager/GUI.lua:230
 CLM.L["DKP value that will be awarded."] = "Valor DKP que se otorgará."
--- Modules/RosterManager/Roster.lua:655
+-- Modules/RosterManager/Roster.lua:657
 -- Modules/RosterManager/GUI.lua:477
 -- Modules/RosterManager/GUI.lua:644
 CLM.L["DKP"] = "DKP"
+-- Integrations/GUI.lua:223
+CLM.L["Data"] = "Datos"
 -- Modules/PointManager/GUI.lua:95
 -- Modules/LootManager/GUI.lua:95
 -- Modules/LootManager/GUI.lua:102
@@ -452,6 +473,8 @@ CLM.L["Decay"] = "Decaimiento"
 CLM.L["Decayed %s%% DKP to %s players in <%s>"] = "%s%% DKP restado a %s jugadores en <%s>"
 -- Modules/LedgerManager/GUI.lua:368
 CLM.L["Decayed %s%% DKP to all players %sin <%s>"] = "Restó %s%% DKP a todos los jugadores %sin <%s>"
+-- Integrations/GUI.lua:147
+CLM.L["December"] = "Diciembre"
 -- Modules/RosterManager/Options.lua:584
 CLM.L["Default Boss Kill Bonus Value"] = "Valor de bonificación por muerte de jefe predeterminado"
 -- Modules/LedgerManager/GUI.lua:122
@@ -472,7 +495,7 @@ CLM.L["Discards all changes and exits sandbox mode"] = "Descarta todos los cambi
 CLM.L["Do not show again"] = "No mostrar de nuevo"
 -- .:indirectly
 CLM.L["Druid"] = "Druida"
--- Modules/RosterManager/Roster.lua:656
+-- Modules/RosterManager/Roster.lua:658
 CLM.L["EPGP"] = "EPGP"
 -- Modules/AutoAwardManager/EncounterIDs.lua:18
 CLM.L["Ebonroc"] = "Ebanorroca"
@@ -519,7 +542,7 @@ CLM.L["Enter sandbox"] = "Entrar en modo Sandbox"
 CLM.L["Epic"] = "Épico"
 -- Modules/AutoAwardManager/EncounterIDs.lua:109
 CLM.L["Eredar Twins"] = "Gemelos Eredar"
--- Modules/RosterManager/Roster.lua:814
+-- Modules/RosterManager/Roster.lua:816
 CLM.L["Europe"] = "Europa"
 -- Modules/RosterManager/GUI.lua:340
 CLM.L["Execute decay for selected players or everyone if none selected."] = "Ejecuta el decaimiento para los jugadores seleccionados o para todos si no se seleccionó ninguno."
@@ -527,8 +550,12 @@ CLM.L["Execute decay for selected players or everyone if none selected."] = "Eje
 CLM.L["Execute migration from MonolithDKP, EssentialDKP or CommunityDKP"] = "Ejecute la migración desde MonolithDKP, EssentialDKP o CommunityDKP"
 -- Migration.lua:51
 CLM.L["Executing Addon Migration with comms disabled."] = "Ejecutando la migración de complementos con las comunicaciones deshabilitadas."
--- Global/GlobalSlashCommands.lua:110
-CLM.L["Export data"] = "Exportar datos"
+-- MinimapIcon.lua:80
+-- Integrations/GUI.lua:391
+-- Integrations/GUI.lua:400
+-- Integrations/GUI.lua:477
+-- Integrations/GUI.lua:478
+CLM.L["Export"] = "Exportar"
 -- Modules/RosterManager/GUI.lua:126
 -- Modules/ProfileManager/GUI.lua:82
 CLM.L["External"] = "Externo"
@@ -538,8 +565,10 @@ CLM.L["False"] = "Falso"
 CLM.L["Fankriss the Unyielding"] = "Fankriss el Implacable"
 -- Modules/AutoAwardManager/EncounterIDs.lua:79
 CLM.L["Fathom-Lord Karathress"] = "Señor de las profundidades Karathress"
--- Modules/RosterManager/Roster.lua:752
--- Modules/RosterManager/Roster.lua:784
+-- Integrations/GUI.lua:137
+CLM.L["February"] = "Febrero"
+-- Modules/RosterManager/Roster.lua:754
+-- Modules/RosterManager/Roster.lua:786
 CLM.L["Feet"] = "Pies"
 -- Modules/AutoAwardManager/EncounterIDs.lua:108
 CLM.L["Felmyst"] = "Brumavil"
@@ -561,9 +590,15 @@ CLM.L["Filter"] = "Filtro"
 -- Modules/RosterManager/GUI.lua:132
 -- Modules/ProfileManager/GUI.lua:86
 CLM.L["Filtering"] = "Filtración"
--- Modules/RosterManager/Roster.lua:753
--- Modules/RosterManager/Roster.lua:785
+-- Modules/RosterManager/Roster.lua:755
+-- Modules/RosterManager/Roster.lua:787
 CLM.L["Finger"] = "Dedo"
+-- Integrations/GUI.lua:275
+CLM.L["Finish Day"] = "Día de finalización"
+-- Integrations/GUI.lua:286
+CLM.L["Finish Month"] = "Mes de finalización"
+-- Integrations/GUI.lua:297
+CLM.L["Finish Year"] = "Año de finalización"
 -- Modules/LedgerManager/GUI.lua:431
 CLM.L["Finished raid %s"] = "Raid terminada %s"
 -- Modules/RaidManager/RaidManager.lua:804
@@ -572,7 +607,9 @@ CLM.L["Finished"] = "Finalizado"
 CLM.L["Firemaw"] = "Faucefogo"
 -- Modules/AutoAwardManager/EncounterIDs.lua:19
 CLM.L["Flamegor"] = "Flamegor"
--- Global/GlobalSlashCommands.lua:128
+-- Integrations/GUI.lua:233
+CLM.L["Format"] = "Formato"
+-- Global/GlobalSlashCommands.lua:118
 CLM.L["Found %s in guild."] = "Encontrado% s en la Hermandad."
 -- Modules/ProfileManager/GUI.lua:440
 CLM.L["GM"] = "GM"
@@ -606,20 +643,20 @@ CLM.L["Gurtogg Bloodboil"] = "Gurtogg Sangre Hirviente"
 CLM.L["Hakkar"] = "Hakkar"
 -- Modules/AutoAwardManager/EncounterIDs.lua:103
 CLM.L["Halazzi"] = "Halazzi"
--- Modules/RosterManager/Roster.lua:749
--- Modules/RosterManager/Roster.lua:781
+-- Modules/RosterManager/Roster.lua:751
+-- Modules/RosterManager/Roster.lua:783
 CLM.L["Hands"] = "Manos"
 -- Modules/LedgerManager/GUI.lua:146
 CLM.L["Hard DKP cap"] = "Límite máximo DKP"
 -- Modules/RosterManager/Options.lua:696
 CLM.L["Hard cap"] = "Límite máximo"
--- Modules/RosterManager/Roster.lua:740
--- Modules/RosterManager/Roster.lua:772
+-- Modules/RosterManager/Roster.lua:742
+-- Modules/RosterManager/Roster.lua:774
 CLM.L["Head"] = "Cabeza"
 -- Modules/AutoAwardManager/EncounterIDs.lua:39
 CLM.L["Heigan the Unclean"] = "Heigan el Impuro"
--- Modules/RosterManager/Roster.lua:758
--- Modules/RosterManager/Roster.lua:790
+-- Modules/RosterManager/Roster.lua:760
+-- Modules/RosterManager/Roster.lua:792
 CLM.L["Held In Off-hand"] = "Sostenido en la mano izquierda"
 -- Modules/AutoAwardManager/EncounterIDs.lua:104
 CLM.L["Hex Lord Malacrass"] = "Señor aojador Malacrass"
@@ -679,7 +716,7 @@ CLM.L["In Progress"] = "En curso"
 CLM.L["In Raid"] = "En Raid"
 -- Modules/LedgerManager/GUI.lua:477
 CLM.L["In sandbox mode all communication is disabled and changes are local until applied. Click Apply changes to store changes and exit sandbox mode. Click Discard to undo changes and exit sandbox mode. /reload will discard changes. Entering sandbox mode will cancel time travel."] = "En el modo sandbox, todas las comunicaciones están deshabilitadas y los cambios son locales hasta que se apliquen. Haga clic en Aplicar cambios para almacenar los cambios y salir del modo Sandbox. Haga clic en Descartar para descartar los cambios y salir del modo Sandbox. /reload deshará los cambios. Entrar en el modo Sandbox cancelará Timetravel."
--- MinimapIcon.lua:134
+-- MinimapIcon.lua:140
 CLM.L["In-Sync"] = "En Sincronización"
 -- Modules/RaidManager/GUI.lua:289
 -- Modules/RosterManager/Options.lua:646
@@ -690,11 +727,11 @@ CLM.L["Include bench"] = "Incluir banquillo"
 CLM.L["Include benched players in all auto-awards"] = "Incluir jugadores en el banquillo en todas las recompensas automáticas"
 -- Modules/RosterManager/GUI.lua:331
 CLM.L["Include players with negative standings."] = "Incluir jugadores con valoraciones negativas."
--- MinimapIcon.lua:132
+-- MinimapIcon.lua:138
 CLM.L["Incoherent state"] = "Estado incoherente"
 -- Modules/RosterManager/GUI.lua:644
 CLM.L["Information"] = "Información"
--- Global/GlobalSlashCommands.lua:123
+-- Global/GlobalSlashCommands.lua:113
 CLM.L["Input name: %s"] = "Nombre de entrada: %s"
 -- Modules/AutoAwardManager/EncounterIDs.lua:41
 CLM.L["Instructor Razuvious"] = "Instructor Razuvious"
@@ -719,7 +756,7 @@ CLM.L["Interval Value"] = "Valor de bonificación de intervalo"
 CLM.L["Interval in [minutes] to award bonus points"] = "Intervalo en [minutos] para otorgar puntos de bonificación"
 -- Modules/AuctionManager/AuctionManager.lua:664
 CLM.L["Invalid bid value"] = "Valor de oferta no válido"
--- Global/GlobalSlashCommands.lua:167
+-- Global/GlobalSlashCommands.lua:157
 CLM.L["Invalid item link"] = "Enlace de artículo no válido"
 -- Global/GlobalChatMessageHandlers.lua:60
 CLM.L["Invalid value provided"] = "Valor proporcionado no válido"
@@ -727,23 +764,29 @@ CLM.L["Invalid value provided"] = "Valor proporcionado no válido"
 CLM.L["Item Value Mode"] = "Modo de valor del artículo"
 -- Modules/RosterManager/Options.lua:739
 CLM.L["Item value mode"] = "Modo de valor del artículo"
--- Global/GlobalSlashCommands.lua:173
+-- Global/GlobalSlashCommands.lua:163
 CLM.L["Item value must be positive"] = "El valor del artículo debe ser positivo"
 -- Modules/RosterManager/Options.lua:815
 CLM.L["Item value overrides"] = "Reemplazos del valor del artículo"
 -- Modules/BiddingManager/GUI.lua:236
--- Modules/AuctionManager/GUI.lua:324
+-- Modules/AuctionManager/GUI.lua:273
 -- Modules/LootManager/GUI.lua:93
 -- Modules/LootManager/GUI.lua:100
 CLM.L["Item"] = "Articulo"
 -- Modules/AutoAwardManager/EncounterIDs.lua:102
 CLM.L["Jan'alai"] = "Jan'alai"
+-- Integrations/GUI.lua:136
+CLM.L["January"] = "Enero"
 -- Modules/AutoAwardManager/EncounterIDs.lua:52
 CLM.L["Jin'do the Hexxer"] = "Jin'do el Malhechor"
 -- Global/GlobalConfigs.lua:36
 CLM.L["Join our discord for more info: |cff44cc44https://tiny.one/clm-discord|r"] = "Únete a nuestro discord para más información: |cff44cc44https://tiny.one/clm-discord|r"
 -- Modules/RaidManager/GUI.lua:152
 CLM.L["Join selected raid"] = "Unirse a la raid seleccionada"
+-- Integrations/GUI.lua:142
+CLM.L["July"] = "Julio"
+-- Integrations/GUI.lua:141
+CLM.L["June"] = "Junio"
 -- Modules/AutoAwardManager/EncounterIDs.lua:85
 CLM.L["Kael'thas Sunstrider"] = "Kael'thas Caminante del Sol "
 -- Modules/AutoAwardManager/EncounterIDs.lua:106
@@ -760,6 +803,12 @@ CLM.L["Kil'jaeden"] = "Kil'jaeden"
 CLM.L["Kurinnaxx"] = "Kurinnaxx"
 -- Modules/AutoAwardManager/EncounterIDs.lua:81
 CLM.L["Lady Vashj"] = "Lady Vashj"
+-- Integrations/GUI.lua:315
+CLM.L["Last month"] = "El mes pasado"
+-- Integrations/GUI.lua:308
+CLM.L["Last week"] = "La semana pasada"
+-- Integrations/GUI.lua:322
+CLM.L["Last year"] = "El año pasado"
 -- Modules/RosterManager/GUI.lua:676
 CLM.L["Latest DKP changes:"] = "Últimos cambios de DKP:"
 -- Modules/RosterManager/GUI.lua:657
@@ -769,8 +818,8 @@ CLM.L["Ledger Entries Audit"] = "Auditoría de asientos contables"
 -- Modules/LootQueueManager/LootQueueManager.lua:87
 -- Global/GlobalConfigs.lua:105
 CLM.L["Legendary"] = "Legendaria"
--- Modules/RosterManager/Roster.lua:751
--- Modules/RosterManager/Roster.lua:783
+-- Modules/RosterManager/Roster.lua:753
+-- Modules/RosterManager/Roster.lua:785
 CLM.L["Legs"] = "Piernas"
 -- Modules/AutoAwardManager/EncounterIDs.lua:78
 CLM.L["Leotheras the Blind"] = "Leotheras el Ciego"
@@ -778,7 +827,7 @@ CLM.L["Leotheras the Blind"] = "Leotheras el Ciego"
 CLM.L["Link Alt to Main"] = "Vincular Alter a Main"
 -- Modules/PointManager/PointManager.lua:424
 CLM.L["Linking override"] = "Anulación de vinculación"
--- MinimapIcon.lua:128
+-- MinimapIcon.lua:134
 -- Modules/LootManager/GUI.lua:300
 -- Modules/LedgerManager/GUI.lua:510
 CLM.L["Loading..."] = "Cargando..."
@@ -791,6 +840,7 @@ CLM.L["Logging"] = "Inicio sesión"
 -- Global/GlobalConfigs.lua:153
 CLM.L["Loot Awards"] = "Premios de botín"
 -- MinimapIcon.lua:31
+-- Integrations/GUI.lua:22
 -- Modules/LootManager/GUI.lua:238
 CLM.L["Loot History"] = "Historial de botín"
 -- MinimapIcon.lua:56
@@ -812,8 +862,8 @@ CLM.L["Magmadar"] = "Magmadar"
 CLM.L["Magtheridon"] = "Magtheridon"
 -- Modules/AutoAwardManager/EncounterIDs.lua:64
 CLM.L["Maiden of Virtue"] = "Doncella de Virtud"
--- Modules/RosterManager/Roster.lua:756
--- Modules/RosterManager/Roster.lua:788
+-- Modules/RosterManager/Roster.lua:758
+-- Modules/RosterManager/Roster.lua:790
 CLM.L["Main Hand"] = "Mano Principal"
 -- Modules/ProfileManager/GUI.lua:383
 CLM.L["Main"] = "Mano"
@@ -828,12 +878,14 @@ CLM.L["Management"] = "Gestión"
 CLM.L["Manager"] = "Gerente"
 -- Modules/PointManager/PointManager.lua:417
 CLM.L["Manual adjustment"] = "Ajuste manual"
+-- Integrations/GUI.lua:138
+CLM.L["March"] = "Marzo"
 -- Modules/ProfileManager/GUI.lua:241
 CLM.L["Mark as alt"] = "Marcar como alter"
 -- Modules/ProfileManager/GUI.lua:242
 CLM.L["Marks selected profiles or everyone if none selected as alts of choosen player (from dropdown)."] = "Marca los perfiles seleccionados o todos, si ninguno seleccionó, como alternativos del jugador elegido (del menú desplegable)."
 -- Modules/BiddingManager/GUI.lua:279
--- Modules/AuctionManager/GUI.lua:394
+-- Modules/AuctionManager/GUI.lua:343
 -- Modules/RosterManager/Options.lua:388
 CLM.L["Max"] = "Маx"
 -- Modules/BiddingManager/GUI.lua:437
@@ -846,6 +898,8 @@ CLM.L["Maximum point cap player can receive per raid week. Set to 0 to disable."
 CLM.L["Maximum point cap that player can have. Set to 0 to disable."] = "Límite máximo de puntos que puede tener el jugador. Establecer en 0 para deshabilitar. "
 -- Modules/RosterManager/Options.lua:319
 CLM.L["Maximum value for Ascending auction. Set to 0 to ignore."] = "Valor máximo para subasta Ascendente. Establecer en 0 para ignorar. "
+-- Integrations/GUI.lua:140
+CLM.L["May"] = "Mayo"
 -- MinimapIcon.lua:23
 CLM.L["Menu"] = "Menú"
 -- Migration.lua:165
@@ -874,11 +928,11 @@ CLM.L["Minimum Level"] = "Nivel mínimo"
 CLM.L["Minimum bid: %s."] = "Oferta mínima: %s."
 -- Modules/ProfileManager/GUI.lua:166
 CLM.L["Minimum level of players to fill from guild."] = "Nivel mínimo de jugadores para llenar de la Hermandad."
--- Global/GlobalSlashCommands.lua:206
+-- Global/GlobalSlashCommands.lua:196
 CLM.L["Missing profile %s"] = "Perfil faltante %s"
--- Global/GlobalSlashCommands.lua:184
+-- Global/GlobalSlashCommands.lua:174
 CLM.L["Missing roster name and you are not in raid"] = "Falta el nombre del roster y no estás en raid"
--- Global/GlobalSlashCommands.lua:188
+-- Global/GlobalSlashCommands.lua:178
 CLM.L["Missing roster name. Using Raid Info"] = "Falta el nombre del roster. Uso de información de la raid"
 -- Modules/RaidManager/RaidManager.lua:377
 -- Modules/RaidManager/RaidManager.lua:433
@@ -899,15 +953,15 @@ CLM.L["Mother Shahraz"] = "Madre Shahraz"
 -- Modules/AutoAwardManager/EncounterIDs.lua:101
 CLM.L["Nalorakk"] = "Nalorakk"
 -- Modules/RaidManager/GUI.lua:387
--- Modules/AuctionManager/GUI.lua:227
+-- Modules/AuctionManager/GUI.lua:176
 -- Modules/RosterManager/GUI.lua:476
 -- Modules/RosterManager/Options.lua:488
 -- Modules/ProfileManager/GUI.lua:374
 CLM.L["Name"] = "Nombre"
 -- Modules/AutoAwardManager/EncounterIDs.lua:171
 CLM.L["Naxxramas"] = "Naxxramas"
--- Modules/RosterManager/Roster.lua:741
--- Modules/RosterManager/Roster.lua:773
+-- Modules/RosterManager/Roster.lua:743
+-- Modules/RosterManager/Roster.lua:775
 CLM.L["Neck"] = "Cuello"
 -- Modules/AutoAwardManager/EncounterIDs.lua:21
 CLM.L["Nefarian"] = "Nefarian"
@@ -940,8 +994,8 @@ CLM.L["No points received"] = "No se recibieron puntos"
 CLM.L["No profile for "] = "Sin perfil para "
 -- Utils.lua:452
 CLM.L["No"] = "No"
--- Modules/RosterManager/Roster.lua:763
--- Modules/RosterManager/Roster.lua:795
+-- Modules/RosterManager/Roster.lua:765
+-- Modules/RosterManager/Roster.lua:797
 CLM.L["Non-equippable"] = "No equipable"
 -- Modules/RaidManager/GUI.lua:430
 -- Modules/RosterManager/GUI.lua:205
@@ -956,8 +1010,8 @@ CLM.L["Not in a roster"] = "No en un roster"
 CLM.L["Not in raid"] = "No en raid"
 -- Modules/RosterManager/GUI.lua:241
 CLM.L["Note to be added to award. Max 32 characters. It is recommended to not include date nor selected reason here. If you will input encounter ID it will be transformed into boss name."] = "Nota para ser añadida al premio. 32 caracteres como máximo. Se recomienda no incluir fecha ni motivo seleccionado aquí. Si ingresa la identificación del encuentro, se transformará en el nombre del jefe."
--- Modules/AuctionManager/GUI.lua:344
--- Modules/AuctionManager/GUI.lua:350
+-- Modules/AuctionManager/GUI.lua:293
+-- Modules/AuctionManager/GUI.lua:299
 -- Modules/RosterManager/GUI.lua:239
 -- Modules/PointManager/GUI.lua:178
 CLM.L["Note"] = "Nota"
@@ -967,10 +1021,14 @@ CLM.L["Noth the Plaguebringer"] = "Noth el Pesteador"
 CLM.L["Notify that you are passing on the item. Cancels any existing bids."] = "Notifique que está pasando el artículo. Cancela cualquier oferta existente."
 -- Modules/BiddingManager/GUI.lua:308
 CLM.L["Notify that you are passing on the item."] = "Notifique que está pasando el artículo."
+-- Integrations/GUI.lua:146
+CLM.L["November"] = "Noviembre"
 -- Modules/LedgerManager/GUI.lua:52
 CLM.L["Num"] = "Número"
--- Modules/RosterManager/Roster.lua:757
--- Modules/RosterManager/Roster.lua:789
+-- Integrations/GUI.lua:145
+CLM.L["October"] = "Octubre"
+-- Modules/RosterManager/Roster.lua:759
+-- Modules/RosterManager/Roster.lua:791
 CLM.L["Off Hand"] = "Mano izquierda"
 -- Modules/RaidManager/GUI.lua:206
 -- Modules/RaidManager/GUI.lua:243
@@ -984,8 +1042,8 @@ CLM.L["On Time Bonus value"] = "Valor de bonificación a tiempo"
 -- Modules/PointManager/PointManager.lua:410
 -- Modules/LedgerManager/GUI.lua:125
 CLM.L["On Time Bonus"] = "Bono de tiempo"
--- Modules/RosterManager/Roster.lua:755
--- Modules/RosterManager/Roster.lua:787
+-- Modules/RosterManager/Roster.lua:757
+-- Modules/RosterManager/Roster.lua:789
 CLM.L["One-Hand"] = "Una mano"
 -- Modules/RosterManager/Options.lua:654
 -- Modules/LedgerManager/GUI.lua:167
@@ -996,7 +1054,7 @@ CLM.L["Only when ML/RL"] = "Solo cuando ML/RL"
 CLM.L["Onyxia"] = "Onyxia"
 -- Modules/AutoAwardManager/EncounterIDs.lua:119
 CLM.L["Onyxia's Lair"] = "Guarida de Onyxia"
--- Modules/RosterManager/Roster.lua:676
+-- Modules/RosterManager/Roster.lua:678
 CLM.L["Open"] = "Abierto"
 -- Modules/AutoAwardManager/EncounterIDs.lua:65
 CLM.L["Opera Hall"] = "Ópera"
@@ -1025,6 +1083,7 @@ CLM.L["Player"] = "Jugador"
 -- Modules/RaidManager/GUI.lua:115
 CLM.L["Please select a raid"] = "Seleccione una raid"
 -- MinimapIcon.lua:35
+-- Integrations/GUI.lua:21
 -- Modules/PointManager/GUI.lua:217
 CLM.L["Point History"] = "Historial de puntos"
 -- Modules/RosterManager/Options.lua:672
@@ -1059,10 +1118,10 @@ CLM.L["Prune profiles"] = "Cortar los perfiles"
 -- Modules/RaidManager/GUI.lua:298
 -- Modules/RosterManager/Options.lua:720
 CLM.L["Put players leaving raid on bench instead of removing them. To remove them completely they will need to be removed manually from the bench."] = "Poner a los jugadores que salen de raid en el banquillo en lugar de eliminarlos. Para eliminarlos por completo, será necesario retirarlos manualmente del banquillo. "
--- Modules/RosterManager/Roster.lua:767
--- Modules/RosterManager/Roster.lua:799
+-- Modules/RosterManager/Roster.lua:769
+-- Modules/RosterManager/Roster.lua:801
 CLM.L["Quiver"] = "Carcaj"
--- Modules/RosterManager/Roster.lua:657
+-- Modules/RosterManager/Roster.lua:659
 CLM.L["ROLL"] = "Tirada de dados"
 -- Modules/AutoAwardManager/EncounterIDs.lua:95
 CLM.L["Rage Winterchill"] = "Ira Fríoinvierno"
@@ -1098,18 +1157,19 @@ CLM.L["Raid [%s] started"] = "Raid [%s] iniciada"
 -- Modules/RaidManager/RaidManager.lua:503
 -- Modules/RaidManager/RaidManager.lua:537
 CLM.L["Raid management is disabled during time traveling."] = "La gestion de las raids está desactivada durante el Time-traveling"
--- Global/GlobalSlashCommands.lua:190
+-- Global/GlobalSlashCommands.lua:180
 CLM.L["Raid: %s Roster: %s"] = "Raid : %s Roster : %s"
 -- Modules/RosterManager/RosterManager.lua:270
 CLM.L["Raids needed in reset"] = "Raids necesarias para reiniciar"
 -- MinimapIcon.lua:39
+-- Integrations/GUI.lua:23
 -- Modules/RaidManager/GUI.lua:474
 CLM.L["Raids"] = "Raids"
--- Modules/RosterManager/Roster.lua:762
--- Modules/RosterManager/Roster.lua:794
+-- Modules/RosterManager/Roster.lua:764
+-- Modules/RosterManager/Roster.lua:796
 CLM.L["Ranged (wands)"] = "A distancia (varitas)"
--- Modules/RosterManager/Roster.lua:761
--- Modules/RosterManager/Roster.lua:793
+-- Modules/RosterManager/Roster.lua:763
+-- Modules/RosterManager/Roster.lua:795
 CLM.L["Ranged"] = "A distancia"
 -- Modules/ProfileManager/GUI.lua:384
 CLM.L["Rank"] = "Rango"
@@ -1123,8 +1183,8 @@ CLM.L["Razorgore the Untamed"] = "Sangrevaja el Indomable"
 -- Modules/RosterManager/GUI.lua:254
 -- Modules/PointManager/GUI.lua:94
 CLM.L["Reason"] = "Razón"
--- Modules/RosterManager/Roster.lua:768
--- Modules/RosterManager/Roster.lua:800
+-- Modules/RosterManager/Roster.lua:770
+-- Modules/RosterManager/Roster.lua:802
 CLM.L["Relic"] = "Reliquia"
 -- Modules/AutoAwardManager/EncounterIDs.lua:91
 CLM.L["Reliquary of Souls"] = "Relicario de almas"
@@ -1161,7 +1221,7 @@ CLM.L["Removes current roster."] = "Elimina el roster actual."
 CLM.L["Removes selected profiles or everyone if none selected."] = "Elimina los perfiles seleccionados o todos si no se seleccionó ninguno."
 -- Modules/RaidManager/GUI.lua:96
 CLM.L["Request standby"] = "Solicitar espera"
--- Global/GlobalSlashCommands.lua:147
+-- Global/GlobalSlashCommands.lua:137
 CLM.L["Reset gui positions"] = "Restablecer posiciones de interfaz gráfica de usuario"
 -- Modules/RaidManager/GUI.lua:108
 CLM.L["Revoke standby"] = "Revocar modo de espera"
@@ -1185,22 +1245,26 @@ CLM.L["Round to"] = "Redondear a"
 CLM.L["Rounding"] = "Redondeo"
 -- Modules/AutoAwardManager/EncounterIDs.lua:208
 CLM.L["Ruins of Ahn'Qiraj"] = "Ruinas de Ahn'Qiraj"
--- Modules/RosterManager/Roster.lua:658
+-- Modules/RosterManager/Roster.lua:660
 CLM.L["SK"] = "SK"
 -- Modules/RosterManager/Options.lua:663
 -- Modules/LedgerManager/GUI.lua:170
 CLM.L["Same zone only"] = "Solo la misma zona"
--- MinimapIcon.lua:142
+-- MinimapIcon.lua:148
 CLM.L["Sandbox mode"] = "Sandbox mode"
 -- Modules/AutoAwardManager/EncounterIDs.lua:44
 CLM.L["Sapphiron"] = "Saphiron"
--- Modules/RosterManager/Roster.lua:677
+-- Modules/RosterManager/Roster.lua:679
 CLM.L["Sealed"] = "Sellado"
 -- Modules/RosterManager/GUI.lua:163
 CLM.L["Search for player names. Separate multiple with a comma ','. Minimum 3 characters. Overrides filtering."] = "Buscar nombres de jugadores. Separe los múltiplos con una coma ','. Un mínimo de 3 caracteres. Anula el filtrado."
 -- Modules/RosterManager/GUI.lua:162
 -- Modules/LootManager/GUI.lua:133
 CLM.L["Search"] = "Búsqueda"
+-- Integrations/GUI.lua:368
+CLM.L["Select Profiles to export"] = "Seleccionar Perfiles para exportar"
+-- Integrations/GUI.lua:337
+CLM.L["Select Rosters to export"] = "Seleccionar Rosters para exportar"
 -- Modules/RosterManager/GUI.lua:192
 -- Modules/ProfileManager/GUI.lua:111
 CLM.L["Select all classes."] = "Seleccione todas las clases."
@@ -1231,6 +1295,8 @@ CLM.L["Select roster to create raid for."] = "Seleccione el roster para crear la
 CLM.L["Select roster"] = "Seleccionar el roster"
 -- Modules/RosterManager/Options.lua:679
 CLM.L["Select weekly reset timezone. EU: Wed 07:00 GMT or US: Tue 15:00 GMT"] = "Seleccione la zona horaria de restablecimiento semanal. UE: miércoles 07:00 GMT o EE. UU.: martes 15:00 GMT"
+-- Integrations/GUI.lua:144
+CLM.L["September"] = "Septiembre"
 -- Modules/AutoAwardManager/EncounterIDs.lua:255
 CLM.L["Serpentshrine Cavern"] = "Caverna Santuario Serpiente"
 -- Modules/LedgerManager/GUI.lua:376
@@ -1247,20 +1313,20 @@ CLM.L["Shade of Aran"] = "Sombra de Aran"
 CLM.L["Shaman"] = "Chaman"
 -- Modules/AutoAwardManager/EncounterIDs.lua:9
 CLM.L["Shazzrah"] = "Shazzrah"
--- Modules/RosterManager/Roster.lua:760
--- Modules/RosterManager/Roster.lua:792
+-- Modules/RosterManager/Roster.lua:762
+-- Modules/RosterManager/Roster.lua:794
 CLM.L["Shield"] = "Escudo"
--- Modules/RosterManager/Roster.lua:743
--- Modules/RosterManager/Roster.lua:775
+-- Modules/RosterManager/Roster.lua:745
+-- Modules/RosterManager/Roster.lua:777
 CLM.L["Shirt"] = "Camisa"
--- Modules/RosterManager/Roster.lua:742
--- Modules/RosterManager/Roster.lua:774
+-- Modules/RosterManager/Roster.lua:744
+-- Modules/RosterManager/Roster.lua:776
 CLM.L["Shoulder"] = "Hombro"
 -- Modules/AutoAwardManager/EncounterIDs.lua:23
 CLM.L["Silithid Royalty"] = "Bug Trio"
 -- Modules/RosterManager/Options.lua:740
 CLM.L["Single-Priced (static) or Ascending (in range of min-max) item value."] = "Valor de artículo de precio único (estático) o ascendente (en el rango de mínimo-máximo)."
--- Modules/RosterManager/Roster.lua:698
+-- Modules/RosterManager/Roster.lua:700
 CLM.L["Single-Priced"] = "Precio único"
 -- Migration.lua:160
 CLM.L["Skipping %s"] = "Saltando %s"
@@ -1268,7 +1334,7 @@ CLM.L["Skipping %s"] = "Saltando %s"
 CLM.L["Skipping CommunityDKP"] = "Ignorar CommunityDKP"
 -- Global/GlobalSlashCommands.lua:100
 CLM.L["Spec guild request"] = "Solicitud de especificaciones de la Hermandad"
--- Modules/AuctionManager/GUI.lua:235
+-- Modules/AuctionManager/GUI.lua:184
 -- Modules/RosterManager/GUI.lua:485
 -- Modules/ProfileManager/GUI.lua:382
 CLM.L["Spec"] = "Especificación"
@@ -1283,12 +1349,13 @@ CLM.L["Standby Bonus"] = "Bono de espera"
 -- Modules/RosterManager/GUI.lua:128
 CLM.L["Standby"] = "En espera"
 -- MinimapIcon.lua:27
+-- Integrations/GUI.lua:20
 -- Modules/RosterManager/GUI.lua:739
 -- Modules/LootManager/GUI.lua:416
 CLM.L["Standings"] = "Posiciones"
 -- Modules/RaidManager/GUI.lua:124
 CLM.L["Start selected raid"] = "Iniciar raid seleccionada"
--- Modules/AuctionManager/GUI.lua:433
+-- Modules/AuctionManager/GUI.lua:382
 CLM.L["Start"] = "Comienzo"
 -- Modules/LedgerManager/GUI.lua:415
 CLM.L["Started raid %s"] = "Raid iniciada %s"
@@ -1296,7 +1363,7 @@ CLM.L["Started raid %s"] = "Raid iniciada %s"
 CLM.L["Statistics:"] = "Estadísticas:"
 -- Modules/RaidManager/GUI.lua:388
 CLM.L["Status"] = "Estado"
--- Modules/AuctionManager/GUI.lua:433
+-- Modules/AuctionManager/GUI.lua:382
 CLM.L["Stop"] = "Detener"
 -- Modules/AuctionHistoryManager/AuctionHistoryManager.lua:65
 CLM.L["Store bids"] = "Tienda de ofertas"
@@ -1314,12 +1381,12 @@ CLM.L["Suppress outgoing whispers"] = "Suprimir los susurros salientes"
 CLM.L["Suppresses changelog display until new version is released"] = "Suprime la visualización del registro de cambios hasta que se lanza una nueva versión"
 -- Modules/AutoAwardManager/EncounterIDs.lua:87
 CLM.L["Supremus"] = "Supremus"
--- MinimapIcon.lua:136
+-- MinimapIcon.lua:142
 CLM.L["Sync ongoing"] = "Sincronización en curso"
 -- Modules/RosterManager/Options.lua:417
 CLM.L["TBC"] = "TBC"
--- Modules/RosterManager/Roster.lua:747
--- Modules/RosterManager/Roster.lua:779
+-- Modules/RosterManager/Roster.lua:749
+-- Modules/RosterManager/Roster.lua:781
 CLM.L["Tabard"] = "Tabardo"
 -- Modules/RosterManager/Options.lua:784
 -- Modules/LedgerManager/GUI.lua:176
@@ -1344,16 +1411,16 @@ CLM.L["The Illidari Council"] = "El Consejo Illidari"
 CLM.L["The Lurker Below"] = "El Rondador de abajo"
 -- Modules/AutoAwardManager/EncounterIDs.lua:22
 CLM.L["The Prophet Skeram"] = "El Profeta Skeram"
--- Modules/RosterManager/Roster.lua:766
--- Modules/RosterManager/Roster.lua:798
+-- Modules/RosterManager/Roster.lua:768
+-- Modules/RosterManager/Roster.lua:800
 CLM.L["Thrown"] = "Arma arrojadiza"
 -- Modules/LedgerManager/GUI.lua:512
 CLM.L["Time Travel"] = "Viaje en el tiempo"
--- MinimapIcon.lua:146
+-- MinimapIcon.lua:152
 CLM.L["Time Traveling"] = "Viajar en el tiempo"
 -- Modules/RosterManager/Options.lua:801
 CLM.L["Time in seconds by which auction will be extended if bid is received during last 10 seconds."] = "Tiempo en segundos por el cual se extenderá la subasta si se recibe una oferta durante los últimos 10 segundos."
--- Modules/AuctionManager/GUI.lua:407
+-- Modules/AuctionManager/GUI.lua:356
 CLM.L["Time settings"] = "Ajustes de hora"
 -- Modules/LedgerManager/GUI.lua:53
 CLM.L["Time"] = "Hora"
@@ -1361,7 +1428,7 @@ CLM.L["Time"] = "Hora"
 CLM.L["Timetravel"] = "Viaje en el tiempo"
 -- Modules/AuctionHistoryManager/GUI.lua:279
 CLM.L["Toggle Auction History window display"] = "Alternar la visualización de la ventana Historial de subastas"
--- Modules/AuctionManager/GUI.lua:721
+-- Modules/AuctionManager/GUI.lua:670
 CLM.L["Toggle Auctioning window display"] = "Alternar la visualización de la ventana de Subastas"
 -- Modules/BiddingManager/BiddingManager.lua:65
 CLM.L["Toggle Bidding auto-open"] = "Alternar ofertas de apertura automática"
@@ -1382,6 +1449,8 @@ CLM.L["Toggle auto open and auto close on auction start and stop"] = "Alternar e
 CLM.L["Toggle changelog window display"] = "Alternar la visualización de la ventana de registro de cambios"
 -- Modules/Changelog/GUI.lua:49
 CLM.L["Toggle changelog"] = "Alternar registro de cambios"
+-- Integrations/GUI.lua:506
+CLM.L["Toggle export window display"] = "Alternar visualización de la ventana de exportación"
 -- Modules/LootManager/GUI.lua:417
 CLM.L["Toggle loot window display"] = "Alternar la visualización de la ventana de botín"
 -- Modules/PointManager/GUI.lua:357
@@ -1406,15 +1475,15 @@ CLM.L["Total received"] = "Total recibido"
 CLM.L["Total spent"] = "Total gastado"
 -- Modules/LootQueueManager/LootQueueManager.lua:77
 CLM.L["Tracked loot rarity"] = "Rareza del botín rastreado"
--- Modules/RosterManager/Roster.lua:754
--- Modules/RosterManager/Roster.lua:786
+-- Modules/RosterManager/Roster.lua:756
+-- Modules/RosterManager/Roster.lua:788
 CLM.L["Trinket"] = "Trinket"
 -- Modules/LedgerManager/GUI.lua:38
 CLM.L["True"] = "Verdad"
 -- Modules/AutoAwardManager/EncounterIDs.lua:28
 CLM.L["Twin Emperors"] = "Emperadores Gemelos"
--- Modules/RosterManager/Roster.lua:759
--- Modules/RosterManager/Roster.lua:791
+-- Modules/RosterManager/Roster.lua:761
+-- Modules/RosterManager/Roster.lua:793
 CLM.L["Two-Hand"] = "Dos manos"
 -- Modules/RosterManager/Options.lua:732
 CLM.L["Type of auction used: Open, Anonymous Open, Sealed, Vickrey (Sealed with second-highest pay price)."] = "Tipo de subasta utilizada: Abierta, Anónima Abierta, Sellada, Vickrey (Sellada con el segundo precio de pago más alto)."
@@ -1427,12 +1496,12 @@ CLM.L["Unable to execute migration. Entries already exist."] = "No se puede ejec
 CLM.L["Uncommon"] = "Poco común"
 -- Modules/PointManager/PointManager.lua:415
 CLM.L["Unexcused absence"] = "Ausencia sin excusa"
--- Global/GlobalSlashCommands.lua:195
+-- Global/GlobalSlashCommands.lua:185
 CLM.L["Unknown roster %s"] = "Roster desconocida %s"
--- MinimapIcon.lua:138
+-- MinimapIcon.lua:144
 CLM.L["Unknown sync state"] = "Estado de sincronización desconocido"
--- Modules/BiddingManager/BiddingManager.lua:253
--- Modules/BiddingManager/BiddingManager.lua:254
+-- Modules/BiddingManager/BiddingManager.lua:243
+-- Modules/BiddingManager/BiddingManager.lua:244
 -- Modules/RaidManager/GUI.lua:414
 -- Modules/RaidManager/GUI.lua:509
 -- Modules/ProfileManager/Profile.lua:27
@@ -1447,7 +1516,7 @@ CLM.L["UpdatePoints(): Empty targets list"] = "UpdatePoints(): lista de objetivo
 CLM.L["Updated raid <%s> %s joined, %s left, %s benched, %s removed"] = "Raid actualizada <%s> %s se unió, %s se fue, %s se quedó en el banquillo, %s se eliminó"
 -- Modules/AutoAwardManager/EncounterIDs.lua:15
 CLM.L["Vaelastrasz the Corrupt"] = "Vaelastrasz el Corrupto"
--- Modules/AuctionManager/GUI.lua:375
+-- Modules/AuctionManager/GUI.lua:324
 CLM.L["Value ranges"] = "Rangos de valores"
 -- Modules/BiddingManager/GUI.lua:163
 CLM.L["Value to use in custom mode"] = "Valor para usar en modo personalizado"
@@ -1463,14 +1532,14 @@ CLM.L["Verbose"] = "Detallado"
 CLM.L["Version check in guild"] = "Comprobación de versión en la Hermandad"
 -- Modules/ProfileManager/GUI.lua:385
 CLM.L["Version"] = "Versión"
--- Modules/RosterManager/Roster.lua:678
+-- Modules/RosterManager/Roster.lua:680
 CLM.L["Vickrey"] = "Vickrey"
 -- Modules/AutoAwardManager/EncounterIDs.lua:26
 CLM.L["Viscidus"] = "Viscidus"
 -- Modules/AutoAwardManager/EncounterIDs.lua:83
 CLM.L["Void Reaver"] = "Atracador del vacío"
--- Modules/RosterManager/Roster.lua:750
--- Modules/RosterManager/Roster.lua:782
+-- Modules/RosterManager/Roster.lua:752
+-- Modules/RosterManager/Roster.lua:784
 CLM.L["Waist"] = "Cintura"
 -- .:indirectly
 CLM.L["Warlock"] = "Brujo"
@@ -1498,8 +1567,8 @@ CLM.L["Wipes all events from memory. This will trigger resyncing from other user
 CLM.L["Wipes the log history"] = "Borra el historial de registro"
 -- Global/GlobalConfigs.lua:55
 CLM.L["WoW DKP Bot Integration"] = "Integración WoW DKP Bot"
--- Modules/RosterManager/Roster.lua:748
--- Modules/RosterManager/Roster.lua:780
+-- Modules/RosterManager/Roster.lua:750
+-- Modules/RosterManager/Roster.lua:782
 CLM.L["Wrist"] = "Muñeca"
 -- Utils.lua:447
 CLM.L["Yes"] = "Sí"
@@ -1546,9 +1615,9 @@ CLM.L["You can only start a freshly created raid."] = "Solo puedes iniciar una r
 CLM.L["You can remove max %d players from roster at the same time."] = "Puede eliminar un máximo de %d jugadores del la roster al mismo tiempo."
 -- Debug.lua:182
 CLM.L["You have just received Kill Command from %s. All Ledger data was wiped. Please reload the UI."] = "Acabas de recibir Kill Command de %s. Se borraron todos los datos del libro mayor. Vuelva a cargar la interfaz de usuario. "
--- Modules/BiddingManager/BiddingManager.lua:254
+-- Modules/BiddingManager/BiddingManager.lua:244
 CLM.L["Your bid (%s) was denied: |cffcc0000%s|r"] = "Su oferta (%s) fue denegada: |cffcc0000%s|r"
--- Modules/BiddingManager/BiddingManager.lua:240
+-- Modules/BiddingManager/BiddingManager.lua:230
 CLM.L["Your bid (%s) was |cff00cc00accepted|r"] = "Su oferta (%s) fue |cff00cc00aceptada|r"
 -- Modules/LedgerManager/GUI.lua:104
 CLM.L["Zero-Sum Bank Inflation"] = "Inflación bancaria de suma cero"
@@ -1636,8 +1705,8 @@ CLM.L["accepted"] = "Aceptado"
 CLM.L["add"] = "añadir"
 -- Modules/RosterManager/GUI.lua:117
 CLM.L["all"] = "todo"
--- Modules/BiddingManager/BiddingManager.lua:238
--- Modules/BiddingManager/BiddingManager.lua:252
+-- Modules/BiddingManager/BiddingManager.lua:228
+-- Modules/BiddingManager/BiddingManager.lua:242
 -- Global/GlobalChatMessageHandlers.lua:50
 CLM.L["cancel"] = "cancelar"
 -- Modules/RosterManager/GUI.lua:541

--- a/Locale/frFR.lua
+++ b/Locale/frFR.lua
@@ -35,7 +35,7 @@ CLM.L["%d %% DKP decay"] = "%d %% Décalage DKP"
 CLM.L["%d DKP"] = "%d DKP"
 -- Modules/LedgerManager/GUI.lua:447
 CLM.L["%d/%m/%Y %H:%M:%S"] = "%d/%m/%Y %H:%M:%S"
--- Modules/LootManager/LootManager.lua:156
+-- Modules/LootManager/LootManager.lua:157
 CLM.L["%s awarded to %s for %s DKP"] = "%s attribué à %s pour %s DKP"
 -- MinimapIcon.lua:129
 CLM.L["%s events (%s pending)"] = "%s événements (%s en attente)"
@@ -130,10 +130,10 @@ CLM.L["Allow players to subscribe to the bench through Raids menu"] = "Autoriser
 -- Modules/RosterManager/Options.lua:711
 -- Modules/LedgerManager/GUI.lua:173
 CLM.L["Allow subscription"] = "Autoriser l'abonnement"
--- Modules/RosterManager/Roster.lua:815
+-- Modules/RosterManager/Roster.lua:817
 CLM.L["Americas"] = "Amériques"
--- Modules/RosterManager/Roster.lua:765
--- Modules/RosterManager/Roster.lua:797
+-- Modules/RosterManager/Roster.lua:767
+-- Modules/RosterManager/Roster.lua:799
 CLM.L["Ammo"] = "Munitions"
 -- Modules/AutoAwardManager/EncounterIDs.lua:96
 CLM.L["Anetheron"] = "Anetheron"
@@ -145,7 +145,7 @@ CLM.L["Announce loot from corpse to Raid"] = "Annoncer le butin au raid"
 CLM.L["Announce loot"] = "Annoncer le butin"
 -- Global/GlobalConfigs.lua:95
 CLM.L["Announcement loot rarity"] = "Annonce de la rareté du butin"
--- Modules/RosterManager/Roster.lua:679
+-- Modules/RosterManager/Roster.lua:681
 CLM.L["Anonymous Open"] = "Anonyme Ouvert"
 -- Modules/RosterManager/Options.lua:800
 CLM.L["Anti-snipe time"] = "Temps anti-snipe"
@@ -163,13 +163,13 @@ CLM.L["Any"] = "Tout"
 CLM.L["Applies all changes and exits sandbox mode"] = "Applique toutes les modifications et quitte le mode Sandbox"
 -- Modules/LedgerManager/GUI.lua:484
 CLM.L["Apply changes"] = "Appliquer les modifications"
--- Integrations/GUI.lua:142
+-- Integrations/GUI.lua:139
 CLM.L["April"] = "Avril"
 -- Modules/AutoAwardManager/EncounterIDs.lua:99
 CLM.L["Archimonde"] = "Archimonde"
 -- Modules/AuctionManager/GUI.lua:436
 CLM.L["Are you sure, you want to award %s to %s for %s DKP?"] = "Êtes-vous sûr de vouloir attribuer %s à %s pour %s DKP ?"
--- Modules/RosterManager/Roster.lua:699
+-- Modules/RosterManager/Roster.lua:701
 CLM.L["Ascending"] = "Ascendant"
 -- Modules/ProfileManager/GUI.lua:444
 CLM.L["Assistant"] = "Assistant"
@@ -226,7 +226,7 @@ CLM.L["Auctioning - History"] = "Vente aux enchères - Historique"
 CLM.L["Auctioning"] = "Vente aux enchères"
 -- MinimapIcon.lua:74
 CLM.L["Audit"] = "Audit"
--- Integrations/GUI.lua:146
+-- Integrations/GUI.lua:143
 CLM.L["August"] = "Auguste"
 -- Modules/LedgerManager/GUI.lua:56
 CLM.L["Author"] = "Auteur"
@@ -274,11 +274,11 @@ CLM.L["Awarding to %s for %d."] = "Attribution à %s pour %d."
 CLM.L["Ayamiss the Hunter"] = "Ayamiss le Chasseur"
 -- Modules/AutoAwardManager/EncounterIDs.lua:98
 CLM.L["Azgalor"] = "Azgalor"
--- Modules/RosterManager/Roster.lua:744
--- Modules/RosterManager/Roster.lua:776
+-- Modules/RosterManager/Roster.lua:746
+-- Modules/RosterManager/Roster.lua:778
 CLM.L["Back"] = "Dos"
--- Modules/RosterManager/Roster.lua:764
--- Modules/RosterManager/Roster.lua:796
+-- Modules/RosterManager/Roster.lua:766
+-- Modules/RosterManager/Roster.lua:798
 CLM.L["Bag"] = "Sac"
 -- Modules/AutoAwardManager/EncounterIDs.lua:8
 CLM.L["Baron Geddon"] = "Baron Geddon"
@@ -292,15 +292,15 @@ CLM.L["Base"] = "Base"
 CLM.L["Base: %d "] = "Base: %d "
 -- Modules/AutoAwardManager/EncounterIDs.lua:24
 CLM.L["Battleguard Sartura"] = "Garde de guerre Sartura"
--- Integrations/GUI.lua:313
--- Integrations/GUI.lua:320
--- Integrations/GUI.lua:327
+-- Integrations/GUI.lua:309
+-- Integrations/GUI.lua:316
+-- Integrations/GUI.lua:323
 CLM.L["Begin %d days ago, finish today."] = "Commencez il y a %d jours, terminez aujourd'hui."
--- Integrations/GUI.lua:246
+-- Integrations/GUI.lua:242
 CLM.L["Begin Day"] = "Jour de début"
--- Integrations/GUI.lua:257
+-- Integrations/GUI.lua:253
 CLM.L["Begin Month"] = "Mois de début"
--- Integrations/GUI.lua:268
+-- Integrations/GUI.lua:264
 CLM.L["Begin Year"] = "Année de début"
 -- Modules/RosterManager/Options.lua:705
 CLM.L["Bench"] = "Banc"
@@ -380,11 +380,11 @@ CLM.L["Channel for posting bids."] = "Canal pour publier des offres."
 CLM.L["Chat Commands"] = "Commandes de discussion"
 -- Modules/AutoAwardManager/EncounterIDs.lua:70
 CLM.L["Chess Event"] = "Chess Event"
--- Modules/RosterManager/Roster.lua:746
--- Modules/RosterManager/Roster.lua:778
+-- Modules/RosterManager/Roster.lua:748
+-- Modules/RosterManager/Roster.lua:780
 CLM.L["Chest (robes)"] = "Torse (robes)"
--- Modules/RosterManager/Roster.lua:745
--- Modules/RosterManager/Roster.lua:777
+-- Modules/RosterManager/Roster.lua:747
+-- Modules/RosterManager/Roster.lua:779
 CLM.L["Chest"] = "Torse"
 -- Modules/AutoAwardManager/EncounterIDs.lua:20
 CLM.L["Chromaggus"] = "Chromaggus"
@@ -401,7 +401,7 @@ CLM.L["Classic"] = "Classic"
 CLM.L["Clear all classes."] = "Effacer toutes les classes."
 -- Modules/ProfileManager/GUI.lua:256
 CLM.L["Clear mains"] = "Effacer mains"
--- Integrations/GUI.lua:477
+-- Integrations/GUI.lua:467
 CLM.L["Clear output"] = "Effacer la sortie"
 -- Modules/ProfileManager/GUI.lua:257
 CLM.L["Clears selected profiles mains."] = "Efface les profils (mains) sélectionnés."
@@ -454,11 +454,11 @@ CLM.L["DKP % that will be decayed."] = "% DKP qui seront diminué."
 CLM.L["DKP & Loot alerts"] = "Alertes DKP et butin"
 -- Modules/RosterManager/GUI.lua:230
 CLM.L["DKP value that will be awarded."] = "Valeur DKP qui sera attribuée."
--- Modules/RosterManager/Roster.lua:655
+-- Modules/RosterManager/Roster.lua:657
 -- Modules/RosterManager/GUI.lua:477
 -- Modules/RosterManager/GUI.lua:644
 CLM.L["DKP"] = "DKP"
--- Integrations/GUI.lua:227
+-- Integrations/GUI.lua:223
 CLM.L["Data"] = "Donnés"
 -- Modules/PointManager/GUI.lua:95
 -- Modules/LootManager/GUI.lua:95
@@ -473,7 +473,7 @@ CLM.L["Decay"] = "Décroissance"
 CLM.L["Decayed %s%% DKP to %s players in <%s>"] = "Dégrader %s%% DKP dégradé pour %s joueurs dans <%s>"
 -- Modules/LedgerManager/GUI.lua:368
 CLM.L["Decayed %s%% DKP to all players %sin <%s>"] = "Dégrader %s%%  pour tous les joueurs %sin <%s>"
--- Integrations/GUI.lua:150
+-- Integrations/GUI.lua:147
 CLM.L["December"] = "Décembre"
 -- Modules/RosterManager/Options.lua:584
 CLM.L["Default Boss Kill Bonus Value"] = "Valeur du bonus de fin de raid"
@@ -495,7 +495,7 @@ CLM.L["Discards all changes and exits sandbox mode"] = "Ignore toutes les modifi
 CLM.L["Do not show again"] = "Ne pas montrer à nouveau"
 -- .:indirectly
 CLM.L["Druid"] = "Druide"
--- Modules/RosterManager/Roster.lua:656
+-- Modules/RosterManager/Roster.lua:658
 CLM.L["EPGP"] = "EPGP"
 -- Modules/AutoAwardManager/EncounterIDs.lua:18
 CLM.L["Ebonroc"] = "Rochébène"
@@ -542,7 +542,7 @@ CLM.L["Enter sandbox"] = "Entrer en mode Sandbox"
 CLM.L["Epic"] = "Epic"
 -- Modules/AutoAwardManager/EncounterIDs.lua:109
 CLM.L["Eredar Twins"] = "Jumelles érédars"
--- Modules/RosterManager/Roster.lua:814
+-- Modules/RosterManager/Roster.lua:816
 CLM.L["Europe"] = "Europe"
 -- Modules/RosterManager/GUI.lua:340
 CLM.L["Execute decay for selected players or everyone if none selected."] = "Выполнить сгорание дкп для выбранных игроков или всех, если никто не выбран."
@@ -551,10 +551,10 @@ CLM.L["Execute migration from MonolithDKP, EssentialDKP or CommunityDKP"] = "Ex�
 -- Migration.lua:51
 CLM.L["Executing Addon Migration with comms disabled."] = "Exécution de la migration des modules complémentaires avec les communications désactivées."
 -- MinimapIcon.lua:80
--- Integrations/GUI.lua:398
--- Integrations/GUI.lua:407
--- Integrations/GUI.lua:487
--- Integrations/GUI.lua:488
+-- Integrations/GUI.lua:391
+-- Integrations/GUI.lua:400
+-- Integrations/GUI.lua:477
+-- Integrations/GUI.lua:478
 CLM.L["Export"] = "Exporter"
 -- Modules/RosterManager/GUI.lua:126
 -- Modules/ProfileManager/GUI.lua:82
@@ -565,10 +565,10 @@ CLM.L["False"] = "Faux"
 CLM.L["Fankriss the Unyielding"] = "Fankriss l'Inflexible"
 -- Modules/AutoAwardManager/EncounterIDs.lua:79
 CLM.L["Fathom-Lord Karathress"] = "Seigneur des fonds Karathress"
--- Integrations/GUI.lua:140
+-- Integrations/GUI.lua:137
 CLM.L["February"] = "Février"
--- Modules/RosterManager/Roster.lua:752
--- Modules/RosterManager/Roster.lua:784
+-- Modules/RosterManager/Roster.lua:754
+-- Modules/RosterManager/Roster.lua:786
 CLM.L["Feet"] = "Pieds"
 -- Modules/AutoAwardManager/EncounterIDs.lua:108
 CLM.L["Felmyst"] = "Gangrebrume"
@@ -590,14 +590,14 @@ CLM.L["Filter"] = "Filtre"
 -- Modules/RosterManager/GUI.lua:132
 -- Modules/ProfileManager/GUI.lua:86
 CLM.L["Filtering"] = "Filtration"
--- Modules/RosterManager/Roster.lua:753
--- Modules/RosterManager/Roster.lua:785
+-- Modules/RosterManager/Roster.lua:755
+-- Modules/RosterManager/Roster.lua:787
 CLM.L["Finger"] = "Doigt"
--- Integrations/GUI.lua:279
+-- Integrations/GUI.lua:275
 CLM.L["Finish Day"] = "Jour de fin"
--- Integrations/GUI.lua:290
+-- Integrations/GUI.lua:286
 CLM.L["Finish Month"] = "Mois de fin"
--- Integrations/GUI.lua:301
+-- Integrations/GUI.lua:297
 CLM.L["Finish Year"] = "Année de fin"
 -- Modules/LedgerManager/GUI.lua:431
 CLM.L["Finished raid %s"] = "Raid terminé %s"
@@ -607,7 +607,7 @@ CLM.L["Finished"] = "Terminé"
 CLM.L["Firemaw"] = "Gueule-de-feu"
 -- Modules/AutoAwardManager/EncounterIDs.lua:19
 CLM.L["Flamegor"] = "Flamegor"
--- Integrations/GUI.lua:237
+-- Integrations/GUI.lua:233
 CLM.L["Format"] = "Format"
 -- Global/GlobalSlashCommands.lua:118
 CLM.L["Found %s in guild."] = "Trouvé %s dans la guilde."
@@ -643,20 +643,20 @@ CLM.L["Gurtogg Bloodboil"] = "Gurtogg Fièvresang"
 CLM.L["Hakkar"] = "Hakkar"
 -- Modules/AutoAwardManager/EncounterIDs.lua:103
 CLM.L["Halazzi"] = "Halazzi"
--- Modules/RosterManager/Roster.lua:749
--- Modules/RosterManager/Roster.lua:781
+-- Modules/RosterManager/Roster.lua:751
+-- Modules/RosterManager/Roster.lua:783
 CLM.L["Hands"] = "Mains"
 -- Modules/LedgerManager/GUI.lua:146
 CLM.L["Hard DKP cap"] = "Hard DKP cap"
 -- Modules/RosterManager/Options.lua:696
 CLM.L["Hard cap"] = "Hard cap"
--- Modules/RosterManager/Roster.lua:740
--- Modules/RosterManager/Roster.lua:772
+-- Modules/RosterManager/Roster.lua:742
+-- Modules/RosterManager/Roster.lua:774
 CLM.L["Head"] = "Tête"
 -- Modules/AutoAwardManager/EncounterIDs.lua:39
 CLM.L["Heigan the Unclean"] = "Heigan l'Impur"
--- Modules/RosterManager/Roster.lua:758
--- Modules/RosterManager/Roster.lua:790
+-- Modules/RosterManager/Roster.lua:760
+-- Modules/RosterManager/Roster.lua:792
 CLM.L["Held In Off-hand"] = "Tenu en main gauche"
 -- Modules/AutoAwardManager/EncounterIDs.lua:104
 CLM.L["Hex Lord Malacrass"] = "Seigneur des maléfices Malacrass"
@@ -775,7 +775,7 @@ CLM.L["Item value overrides"] = "Remplacements de la valeur de l'article"
 CLM.L["Item"] = "Objet"
 -- Modules/AutoAwardManager/EncounterIDs.lua:102
 CLM.L["Jan'alai"] = "Jan'alai"
--- Integrations/GUI.lua:139
+-- Integrations/GUI.lua:136
 CLM.L["January"] = "Janvier"
 -- Modules/AutoAwardManager/EncounterIDs.lua:52
 CLM.L["Jin'do the Hexxer"] = "Jin'do le Maléficieur"
@@ -783,9 +783,9 @@ CLM.L["Jin'do the Hexxer"] = "Jin'do le Maléficieur"
 CLM.L["Join our discord for more info: |cff44cc44https://tiny.one/clm-discord|r"] = "rejoignez notre discord pour plus d'infos : |cff44cc44https://tiny.one/clm-discord|r"
 -- Modules/RaidManager/GUI.lua:152
 CLM.L["Join selected raid"] = "Rejoindre le raid sélectionné"
--- Integrations/GUI.lua:145
+-- Integrations/GUI.lua:142
 CLM.L["July"] = "Juillet"
--- Integrations/GUI.lua:144
+-- Integrations/GUI.lua:141
 CLM.L["June"] = "Juin"
 -- Modules/AutoAwardManager/EncounterIDs.lua:85
 CLM.L["Kael'thas Sunstrider"] = "Kael'thas Haut-soleil"
@@ -803,11 +803,11 @@ CLM.L["Kil'jaeden"] = "Kil'jaeden"
 CLM.L["Kurinnaxx"] = "Kurinnaxx"
 -- Modules/AutoAwardManager/EncounterIDs.lua:81
 CLM.L["Lady Vashj"] = "Dame Vashj"
--- Integrations/GUI.lua:319
+-- Integrations/GUI.lua:315
 CLM.L["Last month"] = "Le mois dernier"
--- Integrations/GUI.lua:312
+-- Integrations/GUI.lua:308
 CLM.L["Last week"] = "La semaine dernière"
--- Integrations/GUI.lua:326
+-- Integrations/GUI.lua:322
 CLM.L["Last year"] = "L'année dernière"
 -- Modules/RosterManager/GUI.lua:676
 CLM.L["Latest DKP changes:"] = "Dernières modifications DKP:"
@@ -818,8 +818,8 @@ CLM.L["Ledger Entries Audit"] = "Audit des écritures comptables"
 -- Modules/LootQueueManager/LootQueueManager.lua:87
 -- Global/GlobalConfigs.lua:105
 CLM.L["Legendary"] = "Légendaire"
--- Modules/RosterManager/Roster.lua:751
--- Modules/RosterManager/Roster.lua:783
+-- Modules/RosterManager/Roster.lua:753
+-- Modules/RosterManager/Roster.lua:785
 CLM.L["Legs"] = "Jambes"
 -- Modules/AutoAwardManager/EncounterIDs.lua:78
 CLM.L["Leotheras the Blind"] = "Leotheras l'Aveugle"
@@ -862,8 +862,8 @@ CLM.L["Magmadar"] = "Magmadar"
 CLM.L["Magtheridon"] = "Magtheridon"
 -- Modules/AutoAwardManager/EncounterIDs.lua:64
 CLM.L["Maiden of Virtue"] = "Damoiselle de vertu"
--- Modules/RosterManager/Roster.lua:756
--- Modules/RosterManager/Roster.lua:788
+-- Modules/RosterManager/Roster.lua:758
+-- Modules/RosterManager/Roster.lua:790
 CLM.L["Main Hand"] = "Main principale"
 -- Modules/ProfileManager/GUI.lua:383
 CLM.L["Main"] = "Main"
@@ -878,7 +878,7 @@ CLM.L["Management"] = "Gestion"
 CLM.L["Manager"] = "Gestionnaire"
 -- Modules/PointManager/PointManager.lua:417
 CLM.L["Manual adjustment"] = "Réglage manuel"
--- Integrations/GUI.lua:141
+-- Integrations/GUI.lua:138
 CLM.L["March"] = "Mars"
 -- Modules/ProfileManager/GUI.lua:241
 CLM.L["Mark as alt"] = "Marquer comme reroll"
@@ -898,7 +898,7 @@ CLM.L["Maximum point cap player can receive per raid week. Set to 0 to disable."
 CLM.L["Maximum point cap that player can have. Set to 0 to disable."] = "Limite maximale de points que le joueur peut avoir. Réglez sur 0 pour désactiver."
 -- Modules/RosterManager/Options.lua:319
 CLM.L["Maximum value for Ascending auction. Set to 0 to ignore."] = "Valeur maximale pour l'enchère ascendante. Mettre à 0 pour ignorer."
--- Integrations/GUI.lua:143
+-- Integrations/GUI.lua:140
 CLM.L["May"] = "Mai"
 -- MinimapIcon.lua:23
 CLM.L["Menu"] = "Menu"
@@ -960,8 +960,8 @@ CLM.L["Nalorakk"] = "Nalorakk"
 CLM.L["Name"] = "Nom"
 -- Modules/AutoAwardManager/EncounterIDs.lua:171
 CLM.L["Naxxramas"] = "Naxxramas"
--- Modules/RosterManager/Roster.lua:741
--- Modules/RosterManager/Roster.lua:773
+-- Modules/RosterManager/Roster.lua:743
+-- Modules/RosterManager/Roster.lua:775
 CLM.L["Neck"] = "Cou"
 -- Modules/AutoAwardManager/EncounterIDs.lua:21
 CLM.L["Nefarian"] = "Nefarian"
@@ -994,8 +994,8 @@ CLM.L["No points received"] = "Aucun point reçu"
 CLM.L["No profile for "] = "Pas de profil pour "
 -- Utils.lua:452
 CLM.L["No"] = "Non"
--- Modules/RosterManager/Roster.lua:763
--- Modules/RosterManager/Roster.lua:795
+-- Modules/RosterManager/Roster.lua:765
+-- Modules/RosterManager/Roster.lua:797
 CLM.L["Non-equippable"] = "Non-équipable"
 -- Modules/RaidManager/GUI.lua:430
 -- Modules/RosterManager/GUI.lua:205
@@ -1021,14 +1021,14 @@ CLM.L["Noth the Plaguebringer"] = "Noth le Porte-peste"
 CLM.L["Notify that you are passing on the item. Cancels any existing bids."] = "Avertissez que vous passé l'article. Annule toutes les offres existantes."
 -- Modules/BiddingManager/GUI.lua:308
 CLM.L["Notify that you are passing on the item."] = "Avertissez que vous passé l'article."
--- Integrations/GUI.lua:149
+-- Integrations/GUI.lua:146
 CLM.L["November"] = "Novembre"
 -- Modules/LedgerManager/GUI.lua:52
 CLM.L["Num"] = "Nombre"
--- Integrations/GUI.lua:148
+-- Integrations/GUI.lua:145
 CLM.L["October"] = "Octobre"
--- Modules/RosterManager/Roster.lua:757
--- Modules/RosterManager/Roster.lua:789
+-- Modules/RosterManager/Roster.lua:759
+-- Modules/RosterManager/Roster.lua:791
 CLM.L["Off Hand"] = "Main gauche"
 -- Modules/RaidManager/GUI.lua:206
 -- Modules/RaidManager/GUI.lua:243
@@ -1042,8 +1042,8 @@ CLM.L["On Time Bonus value"] = "Valeur du bonus du temps"
 -- Modules/PointManager/PointManager.lua:410
 -- Modules/LedgerManager/GUI.lua:125
 CLM.L["On Time Bonus"] = "Bonus au temps"
--- Modules/RosterManager/Roster.lua:755
--- Modules/RosterManager/Roster.lua:787
+-- Modules/RosterManager/Roster.lua:757
+-- Modules/RosterManager/Roster.lua:789
 CLM.L["One-Hand"] = "Une main"
 -- Modules/RosterManager/Options.lua:654
 -- Modules/LedgerManager/GUI.lua:167
@@ -1054,7 +1054,7 @@ CLM.L["Only when ML/RL"] = "Uniquement lorsque ML/RL"
 CLM.L["Onyxia"] = "Onyxia"
 -- Modules/AutoAwardManager/EncounterIDs.lua:119
 CLM.L["Onyxia's Lair"] = "Repaire d'Onyxia"
--- Modules/RosterManager/Roster.lua:676
+-- Modules/RosterManager/Roster.lua:678
 CLM.L["Open"] = "Ouvert"
 -- Modules/AutoAwardManager/EncounterIDs.lua:65
 CLM.L["Opera Hall"] = "L'Opéra"
@@ -1118,10 +1118,10 @@ CLM.L["Prune profiles"] = "Tailler les profils"
 -- Modules/RaidManager/GUI.lua:298
 -- Modules/RosterManager/Options.lua:720
 CLM.L["Put players leaving raid on bench instead of removing them. To remove them completely they will need to be removed manually from the bench."] = "Mettez les joueurs quittant le raid sur le banc au lieu de les retirer. Pour les retirer complètement, ils devront être retirés manuellement du banc."
--- Modules/RosterManager/Roster.lua:767
--- Modules/RosterManager/Roster.lua:799
+-- Modules/RosterManager/Roster.lua:769
+-- Modules/RosterManager/Roster.lua:801
 CLM.L["Quiver"] = "Quiver"
--- Modules/RosterManager/Roster.lua:657
+-- Modules/RosterManager/Roster.lua:659
 CLM.L["ROLL"] = "Jet de dés"
 -- Modules/AutoAwardManager/EncounterIDs.lua:95
 CLM.L["Rage Winterchill"] = "Rage Froidhiver"
@@ -1165,11 +1165,11 @@ CLM.L["Raids needed in reset"] = "Raids nécessaires à la réinitialisation"
 -- Integrations/GUI.lua:23
 -- Modules/RaidManager/GUI.lua:474
 CLM.L["Raids"] = "Raids"
--- Modules/RosterManager/Roster.lua:762
--- Modules/RosterManager/Roster.lua:794
+-- Modules/RosterManager/Roster.lua:764
+-- Modules/RosterManager/Roster.lua:796
 CLM.L["Ranged (wands)"] = "À distance (baguettes)"
--- Modules/RosterManager/Roster.lua:761
--- Modules/RosterManager/Roster.lua:793
+-- Modules/RosterManager/Roster.lua:763
+-- Modules/RosterManager/Roster.lua:795
 CLM.L["Ranged"] = "À distance"
 -- Modules/ProfileManager/GUI.lua:384
 CLM.L["Rank"] = "Rang"
@@ -1183,8 +1183,8 @@ CLM.L["Razorgore the Untamed"] = "Tranchetripe l'Indompté"
 -- Modules/RosterManager/GUI.lua:254
 -- Modules/PointManager/GUI.lua:94
 CLM.L["Reason"] = "Raison"
--- Modules/RosterManager/Roster.lua:768
--- Modules/RosterManager/Roster.lua:800
+-- Modules/RosterManager/Roster.lua:770
+-- Modules/RosterManager/Roster.lua:802
 CLM.L["Relic"] = "Relique"
 -- Modules/AutoAwardManager/EncounterIDs.lua:91
 CLM.L["Reliquary of Souls"] = "Reliquaire des âmes"
@@ -1245,7 +1245,7 @@ CLM.L["Round to"] = "Arrondir à"
 CLM.L["Rounding"] = "Arrondi"
 -- Modules/AutoAwardManager/EncounterIDs.lua:208
 CLM.L["Ruins of Ahn'Qiraj"] = "Ruines d'Ahn'Qiraj"
--- Modules/RosterManager/Roster.lua:658
+-- Modules/RosterManager/Roster.lua:660
 CLM.L["SK"] = "SK"
 -- Modules/RosterManager/Options.lua:663
 -- Modules/LedgerManager/GUI.lua:170
@@ -1254,16 +1254,16 @@ CLM.L["Same zone only"] = "Même zone uniquement"
 CLM.L["Sandbox mode"] = "Sandbox mode"
 -- Modules/AutoAwardManager/EncounterIDs.lua:44
 CLM.L["Sapphiron"] = "Saphiron"
--- Modules/RosterManager/Roster.lua:677
+-- Modules/RosterManager/Roster.lua:679
 CLM.L["Sealed"] = "Scellé"
 -- Modules/RosterManager/GUI.lua:163
 CLM.L["Search for player names. Separate multiple with a comma ','. Minimum 3 characters. Overrides filtering."] = "Rechercher des noms de joueurs. Séparez les multiples par une virgule ','. 3 caractères minimum. Remplace le filtrage."
 -- Modules/RosterManager/GUI.lua:162
 -- Modules/LootManager/GUI.lua:133
 CLM.L["Search"] = "Chercher"
--- Integrations/GUI.lua:374
+-- Integrations/GUI.lua:368
 CLM.L["Select Profiles to export"] = "Sélectionnez les profils à exporter"
--- Integrations/GUI.lua:342
+-- Integrations/GUI.lua:337
 CLM.L["Select Rosters to export"] = "Sélectionnez les listes à exporter"
 -- Modules/RosterManager/GUI.lua:192
 -- Modules/ProfileManager/GUI.lua:111
@@ -1295,7 +1295,7 @@ CLM.L["Select roster to create raid for."] = "Sélectionner la liste pour laquel
 CLM.L["Select roster"] = "Sélectionner la liste"
 -- Modules/RosterManager/Options.lua:679
 CLM.L["Select weekly reset timezone. EU: Wed 07:00 GMT or US: Tue 15:00 GMT"] = "Sélectionnez le fuseau horaire de réinitialisation hebdomadaire. UE : Mercredi 07h00 GMT ou États-Unis : Mar 15h00 GMT"
--- Integrations/GUI.lua:147
+-- Integrations/GUI.lua:144
 CLM.L["September"] = "Septembre"
 -- Modules/AutoAwardManager/EncounterIDs.lua:255
 CLM.L["Serpentshrine Cavern"] = "Caverne du sanctuaire du Serpent"
@@ -1313,20 +1313,20 @@ CLM.L["Shade of Aran"] = "L'ombre d'Aran"
 CLM.L["Shaman"] = "Chaman"
 -- Modules/AutoAwardManager/EncounterIDs.lua:9
 CLM.L["Shazzrah"] = "Shazzrah"
--- Modules/RosterManager/Roster.lua:760
--- Modules/RosterManager/Roster.lua:792
+-- Modules/RosterManager/Roster.lua:762
+-- Modules/RosterManager/Roster.lua:794
 CLM.L["Shield"] = "Bouclier"
--- Modules/RosterManager/Roster.lua:743
--- Modules/RosterManager/Roster.lua:775
+-- Modules/RosterManager/Roster.lua:745
+-- Modules/RosterManager/Roster.lua:777
 CLM.L["Shirt"] = "Chemise"
--- Modules/RosterManager/Roster.lua:742
--- Modules/RosterManager/Roster.lua:774
+-- Modules/RosterManager/Roster.lua:744
+-- Modules/RosterManager/Roster.lua:776
 CLM.L["Shoulder"] = "Épaule"
 -- Modules/AutoAwardManager/EncounterIDs.lua:23
 CLM.L["Silithid Royalty"] = "Bug Trio"
 -- Modules/RosterManager/Options.lua:740
 CLM.L["Single-Priced (static) or Ascending (in range of min-max) item value."] = "Valeur de l'article à prix unique (statique) ou ascendante (dans la plage min-max)."
--- Modules/RosterManager/Roster.lua:698
+-- Modules/RosterManager/Roster.lua:700
 CLM.L["Single-Priced"] = "Prix unique"
 -- Migration.lua:160
 CLM.L["Skipping %s"] = "%s ignoré"
@@ -1385,8 +1385,8 @@ CLM.L["Supremus"] = "Supremus"
 CLM.L["Sync ongoing"] = "Synchronisation en cours"
 -- Modules/RosterManager/Options.lua:417
 CLM.L["TBC"] = "TBC"
--- Modules/RosterManager/Roster.lua:747
--- Modules/RosterManager/Roster.lua:779
+-- Modules/RosterManager/Roster.lua:749
+-- Modules/RosterManager/Roster.lua:781
 CLM.L["Tabard"] = "Tabard"
 -- Modules/RosterManager/Options.lua:784
 -- Modules/LedgerManager/GUI.lua:176
@@ -1411,8 +1411,8 @@ CLM.L["The Illidari Council"] = "Le conseil illidari"
 CLM.L["The Lurker Below"] = "Le Rôdeur d'En bas"
 -- Modules/AutoAwardManager/EncounterIDs.lua:22
 CLM.L["The Prophet Skeram"] = "Le Prophète Skeram"
--- Modules/RosterManager/Roster.lua:766
--- Modules/RosterManager/Roster.lua:798
+-- Modules/RosterManager/Roster.lua:768
+-- Modules/RosterManager/Roster.lua:800
 CLM.L["Thrown"] = "Arme de jet"
 -- Modules/LedgerManager/GUI.lua:512
 CLM.L["Time Travel"] = "Voyage dans le temps"
@@ -1449,7 +1449,7 @@ CLM.L["Toggle auto open and auto close on auction start and stop"] = "Basculer l
 CLM.L["Toggle changelog window display"] = "Basculer l'affichage de la fenêtre du journal des modifications"
 -- Modules/Changelog/GUI.lua:49
 CLM.L["Toggle changelog"] = "Basculer le journal des modifications"
--- Integrations/GUI.lua:516
+-- Integrations/GUI.lua:506
 CLM.L["Toggle export window display"] = "Basculer l'affichage de la fenêtre d'exportation"
 -- Modules/LootManager/GUI.lua:417
 CLM.L["Toggle loot window display"] = "Basculer l'affichage de la fenêtre de butin"
@@ -1475,15 +1475,15 @@ CLM.L["Total received"] = "Total reçu"
 CLM.L["Total spent"] = "Total dépensé"
 -- Modules/LootQueueManager/LootQueueManager.lua:77
 CLM.L["Tracked loot rarity"] = "Suivi de la rareté du butin"
--- Modules/RosterManager/Roster.lua:754
--- Modules/RosterManager/Roster.lua:786
+-- Modules/RosterManager/Roster.lua:756
+-- Modules/RosterManager/Roster.lua:788
 CLM.L["Trinket"] = "Bijou"
 -- Modules/LedgerManager/GUI.lua:38
 CLM.L["True"] = "Vrai"
 -- Modules/AutoAwardManager/EncounterIDs.lua:28
 CLM.L["Twin Emperors"] = "Les Empereurs jumeaux"
--- Modules/RosterManager/Roster.lua:759
--- Modules/RosterManager/Roster.lua:791
+-- Modules/RosterManager/Roster.lua:761
+-- Modules/RosterManager/Roster.lua:793
 CLM.L["Two-Hand"] = "Deux mains"
 -- Modules/RosterManager/Options.lua:732
 CLM.L["Type of auction used: Open, Anonymous Open, Sealed, Vickrey (Sealed with second-highest pay price)."] = "Type d'enchère utilisé : Ouvert, Anonyme Ouvert, Scellé, Vickrey (Scellé avec le deuxième prix le plus élevé)."
@@ -1532,14 +1532,14 @@ CLM.L["Verbose"] = "Détaillé"
 CLM.L["Version check in guild"] = "Vérification de la version dans la guilde"
 -- Modules/ProfileManager/GUI.lua:385
 CLM.L["Version"] = "Version"
--- Modules/RosterManager/Roster.lua:678
+-- Modules/RosterManager/Roster.lua:680
 CLM.L["Vickrey"] = "Vickrey"
 -- Modules/AutoAwardManager/EncounterIDs.lua:26
 CLM.L["Viscidus"] = "Viscidus"
 -- Modules/AutoAwardManager/EncounterIDs.lua:83
 CLM.L["Void Reaver"] = "Saccageur du Vide"
--- Modules/RosterManager/Roster.lua:750
--- Modules/RosterManager/Roster.lua:782
+-- Modules/RosterManager/Roster.lua:752
+-- Modules/RosterManager/Roster.lua:784
 CLM.L["Waist"] = "Taille"
 -- .:indirectly
 CLM.L["Warlock"] = "Démoniste"
@@ -1567,8 +1567,8 @@ CLM.L["Wipes all events from memory. This will trigger resyncing from other user
 CLM.L["Wipes the log history"] = "Efface l'historique du journal"
 -- Global/GlobalConfigs.lua:55
 CLM.L["WoW DKP Bot Integration"] = "Intégration WoW DKP Bot"
--- Modules/RosterManager/Roster.lua:748
--- Modules/RosterManager/Roster.lua:780
+-- Modules/RosterManager/Roster.lua:750
+-- Modules/RosterManager/Roster.lua:782
 CLM.L["Wrist"] = "Poignet"
 -- Utils.lua:447
 CLM.L["Yes"] = "Oui"

--- a/Locale/ruRU.lua
+++ b/Locale/ruRU.lua
@@ -527,8 +527,6 @@ CLM.L["Execute decay for selected players or everyone if none selected."] = "В�
 CLM.L["Execute migration from MonolithDKP, EssentialDKP or CommunityDKP"] = "Выполнить миграцию с MonolithDKP, EssentialDKP или CommunityDKP"
 -- Migration.lua:51
 CLM.L["Executing Addon Migration with comms disabled."] = "Осуществляю миграцию аддона с выключеными оповещениями."
--- Global/GlobalSlashCommands.lua:110
-CLM.L["Export data"] = "Экспорт данных"
 -- Modules/RosterManager/GUI.lua:126
 -- Modules/ProfileManager/GUI.lua:82
 CLM.L["External"] = "Внешние"

--- a/scripts/l10n_strings.py
+++ b/scripts/l10n_strings.py
@@ -179,7 +179,7 @@ def main(args):
 
     # Prepare
     # locales = ["ruRU", "frFR"]
-    locales = ["frFR"]
+    locales = ["frFR", "esES"]
     l10n_query = re.compile('(CLM\.L\[["\'].*?["\']\])')
     l10n_translation_query = re.compile('(CLM\.L\[["\'].*?["\']\])\s*=\s*["\'](.*)["\']')
     storage = L10nStorage(baseDir, args.parser)


### PR DESCRIPTION
Closes #278 

```
Missing translations for locale esES:
CLM.L["Export"]
CLM.L["January"]
CLM.L["February"]
CLM.L["March"]
CLM.L["April"]
CLM.L["May"]
CLM.L["June"]
CLM.L["July"]
CLM.L["August"]
CLM.L["September"]
CLM.L["October"]
CLM.L["November"]
CLM.L["December"]
CLM.L["Data"]
CLM.L["Format"]
CLM.L["Begin Day"]
CLM.L["Begin Month"]
CLM.L["Begin Year"]
CLM.L["Finish Day"]
CLM.L["Finish Month"]
CLM.L["Finish Year"]
CLM.L["Last week"]
CLM.L["Begin %d days ago, finish today."]
CLM.L["Last month"]
CLM.L["Last year"]
CLM.L["Select Rosters to export"]
CLM.L["Select Profiles to export"]
CLM.L["Clear output"]
CLM.L["Toggle export window display"]