### PR TITLE
Rewrite class info

### DIFF
--- a/Modules/ProfileManager/ProfileManager.lua
+++ b/Modules/ProfileManager/ProfileManager.lua
@@ -37,7 +37,7 @@ function ProfileManager:Initialize()
             local name = entry:name()
             if UTILS.empty(name) then return end
 
-            local class = UTILS.GetClassReadable(UTILS.NumberToClass(entry:ingameClass()))
+            local class = UTILS.NumberToClass(entry:ingameClass()) or ""
             local main = entry:main()
             main =  (type(main) == "number" and main ~= 0) and UTILS.getGuidFromInteger(main) or ""
             -- Check if it's an update

--- a/Utils.lua
+++ b/Utils.lua
@@ -26,26 +26,54 @@ local function capitalize(string)
     return supper(ssub(string, 1,1)) .. slower(ssub(string, 2))
 end
 
-local classOrdered = {
-    "Death Knight", "Druid", "Hunter", "Mage", "Priest", "Rogue", "Shaman", "Paladin", "Warlock", "Warrior"
+local numberToClass = {
+    [1]  = "Warrior",
+    [2]  = "Paladin",
+    [3]  = "Hunter",
+    [4]  = "Rogue",
+    [5]  = "Priest",
+    [6]  = "Death Knight",
+    [7]  = "Shaman",
+    [8]  = "Mage",
+    [9]  = "Warlock",
+    -- [10] = "Monk",
+    [11] = "Druid",
+    -- [12] = "Demon Hunter"
 }
 
+local classOrdered = {}
+local classToNumber = {}
+local index = 0
+for k, v in pairs(numberToClass) do
+    print(tostring(v)..k)
+    classToNumber[v] = k
+    classOrdered[index] = v
+    index = index +1
+end
+
+function UTILS.ClassToNumber(class)
+    return classToNumber[class] or 0
+end
+
+function UTILS.NumberToClass(number)
+    return numberToClass[number] or ""
+end
+
 local classColors = {
-    ["deathknight"]     = { a = 1, r = 0.77, g = 0.12, b = 0.23, hex = "C41E3A" },
-    ["druid"]           = { a = 1, r = 1,    g = 0.49, b = 0.04, hex = "FF7D0A" },
-    ["hunter"]          = { a = 1, r = 0.67, g = 0.83, b = 0.45, hex = "ABD473" },
-    ["mage"]            = { a = 1, r = 0.25, g = 0.78, b = 0.92, hex = "40C7EB" },
-    ["priest"]          = { a = 1, r = 1,    g = 1,    b = 1,    hex = "FFFFFF" },
-    ["rogue"]           = { a = 1, r = 1,    g = 0.96, b = 0.41, hex = "FFF569" },
-    ["shaman"]          = { a = 1, r = 0.01, g = 0.44, b = 0.87, hex = "0270DD" },
-    ["paladin"]         = { a = 1, r = 0.96, g = 0.55, b = 0.73, hex = "F58CBA" },
-    ["warlock"]         = { a = 1, r = 0.53, g = 0.53, b = 0.93, hex = "8787ED" },
-    ["warrior"]         = { a = 1, r = 0.78, g = 0.61, b = 0.43, hex = "C79C6E" },
-    ["death knight"]    = { a = 1, r = 0.77, g = 0.12, b = 0.23, hex = "C41E3A" }
+    ["Druid"]           = { a = 1, r = 1,    g = 0.49, b = 0.04, hex = "FF7D0A" },
+    ["Hunter"]          = { a = 1, r = 0.67, g = 0.83, b = 0.45, hex = "ABD473" },
+    ["Mage"]            = { a = 1, r = 0.25, g = 0.78, b = 0.92, hex = "40C7EB" },
+    ["Priest"]          = { a = 1, r = 1,    g = 1,    b = 1,    hex = "FFFFFF" },
+    ["Rogue"]           = { a = 1, r = 1,    g = 0.96, b = 0.41, hex = "FFF569" },
+    ["Shaman"]          = { a = 1, r = 0.01, g = 0.44, b = 0.87, hex = "0270DD" },
+    ["Paladin"]         = { a = 1, r = 0.96, g = 0.55, b = 0.73, hex = "F58CBA" },
+    ["Warlock"]         = { a = 1, r = 0.53, g = 0.53, b = 0.93, hex = "8787ED" },
+    ["Warrior"]         = { a = 1, r = 0.78, g = 0.61, b = 0.43, hex = "C79C6E" },
+    ["Death Knight"]    = { a = 1, r = 0.77, g = 0.12, b = 0.23, hex = "C41E3A" }
 }
 
 function UTILS.GetClassColor(className)
-    local color = classColors[slower(className)]
+    local color = classColors[className]
     return (color or { r = 0.627, g = 0.627, b = 0.627, hex = "A0A0A0" })
 end
 local GetClassColor = UTILS.GetClassColor
@@ -372,47 +400,6 @@ function UTILS.mergeDictsInline(t, s)
     for k,v in pairs(s) do t[k] = v end
 end
 
-local classToNumber = {
-    ["WARRIOR"] = 1,
-    ["PALADIN"] = 2,
-    ["HUNTER"] = 3,
-    ["ROGUE"] = 4,
-    ["PRIEST"] = 5,
-    ["DEATHKNIGHT"] = 6,
-    ["SHAMAN"] = 7,
-    ["MAGE"] = 8,
-    ["WARLOCK"] = 9,
-    ["MONK"] = 10,
-    ["DRUID"] = 11,
-    ["DEMONHUNTER"] = 12
-}
-function UTILS.ClassToNumber(class)
-    return classToNumber[(class or ""):upper()] or 0
-end
-
-local numberToClass = {
-    [1]  = "WARRIOR",
-    [2]  = "PALADIN",
-    [3]  = "HUNTER",
-    [4]  = "ROGUE",
-    [5]  = "PRIEST",
-    [6]  = "DEATHKNIGHT",
-    [7]  = "SHAMAN",
-    [8]  = "MAGE",
-    [9]  = "WARLOCK",
-    -- [10] = "MONK",
-    [11] = "DRUID",
-    -- [12] = "DEMONHUNTER"
-}
-function UTILS.NumberToClass(number)
-    return supper((numberToClass[number] or ""))
-end
-
-function UTILS.GetClassReadable(class)
-    if class == "DEATHKNIGHT" then return CLM.L["Death Knight"] end
-    return capitalize(class or "")
-end
-
 function UTILS.capitalize(string)
     return capitalize(string)
 end
@@ -701,6 +688,7 @@ end
 function UTILS.LibStClassCellUpdate(rowFrame, frame, data, cols, row, realrow, column, fShow, table, ...)
     local class = data[realrow].cols[column].value
     if class then
+        class = supper(sgsub(class, "%s", ""))  -- remove space and to uppercase
         frame:SetNormalTexture("Interface\\GLUES\\CHARACTERCREATE\\UI-CHARACTERCREATE-CLASSES") -- this is the image containing all class icons
         local coords = CLASS_ICON_TCOORDS[class]
         frame:GetNormalTexture():SetTexCoord(unpack(coords))

--- a/Utils.lua
+++ b/Utils.lua
@@ -43,7 +43,6 @@ local classOrdered = {}
 local classToNumber = {}
 local index = 0
 for k, v in pairs(numberToClass) do
-    print(tostring(v)..k)
     classToNumber[v] = k
     classOrdered[index] = v
     index = index +1

--- a/Utils.lua
+++ b/Utils.lua
@@ -48,6 +48,9 @@ for k, v in pairs(numberToClass) do
     index = index +1
 end
 
+-- table.sort(classOrdered, function(a,b) return CLM.L[a]<CLM.L[b] end)
+table.sort(classOrdered)
+
 function UTILS.ClassToNumber(class)
     return classToNumber[class] or 0
 end


### PR DESCRIPTION
1. Unify explicit class information only in table numberToClass
2. other related array and table are generated implicitly (classOrdered, classToNumber)
3. reduce string lower/upper operations as much as possible