### PR TITLE
chore: remove unused functions and make externally unused functions local

### DIFF
--- a/Modules/RosterManager/Roster.lua
+++ b/Modules/RosterManager/Roster.lua
@@ -202,8 +202,8 @@ function Roster:UpdateStandings(GUID, value, timestamp)
     if isPointGain then
         -- Handle the caps if the update was a positive (gain)
         -- Hard Cap
-        if self.configuration.hasHardCap then
-            local hardCap = self.configuration._.hardCap
+        local hardCap = self.configuration._.hardCap
+        if hardCap > 0 then
             -- We do not modify points if they are already exceeded during newly introduced cap
             if (standings >= hardCap) then
                 return
@@ -218,8 +218,9 @@ function Roster:UpdateStandings(GUID, value, timestamp)
         end
         -- Weekly Cap
         week = UTILS.WeekNumber(timestamp, (self.configuration._.weeklyReset == CONSTANTS.WEEKLY_RESET.EU) and weekOffsetEU or weekOffsetUS)
-        if self.configuration.hasWeeklyCap then
-            local maxGain = self.configuration._.weeklyCap - self:GetWeeklyGainsForPlayerWeek(GUID, week)
+        local weeklyCap = self.configuration._.weeklyCap
+        if weeklyCap > 0 then
+            local maxGain = weeklyCap - self:GetWeeklyGainsForPlayerWeek(GUID, week)
             if maxGain < 0 then -- sanity check (here it can be 0 and this can happen if cap was lowered before awarding dkp)
                 LOG:Debug("Roster:UpdateStandings(): maxGain %d for %s(%s) is lower than 0 for weekly cap", maxGain, GUID, self.uid)
                 return

--- a/Modules/RosterManager/RosterConfiguration.lua
+++ b/Modules/RosterManager/RosterConfiguration.lua
@@ -91,7 +91,7 @@ end
 -- ----------------------- --
 -- ADD NEW ONLY AT THE END --
 -- ----------------------- --
-function RosterConfiguration:fields()
+local function fields()
     return {
         "auctionType",
         "itemValueMode",
@@ -169,26 +169,20 @@ local TRANSFORMS = {
 }
 
 function RosterConfiguration:inflate(data)
-    for i, key in ipairs(self:fields()) do
+    for i, key in ipairs(fields()) do
         self._[key] = TRANSFORMS[key](data[i])
     end
 end
 
-function RosterConfiguration:deflate()
-    local result = {}
-    for _, key in ipairs(self:fields()) do
-        table.insert(result, self._[key])
+local function validate(self, option, value)
+    local callback = "_validate_" .. option
+    if type(self[callback]) == "function" then
+        local r = self[callback](value)
+        return r
     end
 
-    return result
+    return true -- TODO: true or false?
 end
-
-function RosterConfiguration:Copy(o)
-    for k,v in pairs(o._) do
-        self._[k] = v
-    end
-end
-
 function RosterConfiguration:Get(option)
     if option ~= nil then
         return self._[option]
@@ -199,22 +193,14 @@ end
 function RosterConfiguration:Set(option, value)
     if option == nil then return end
     if self._[option] ~= nil then
-        if self:Validate(option, value) then
+        if validate(self, option, value) then
             self._[option] = TRANSFORMS[option](value)
             self:PostProcess(option)
         end
     end
 end
 
-function RosterConfiguration:Validate(option, value)
-    local callback = "_validate_" .. option
-    if type(self[callback]) == "function" then
-        local r = self[callback](value)
-        return r
-    end
 
-    return true -- TODO: true or false?
-end
 
 function RosterConfiguration:PostProcess(option)
     if option == "hardCap" then


### PR DESCRIPTION
This cleans up `RosterConfiguration` a bit.

- Remove unused public functions
- Make public functions that are only used via `self:` local instead.