### PR TITLE
Display player name if only one player is affected in history tab

### DIFF
--- a/Modules/GUI/UnifiedGUI_History.lua
+++ b/Modules/GUI/UnifiedGUI_History.lua
@@ -341,7 +341,7 @@ local function tableDataFeeder()
         else -- raid loot
             pointList = roster:GetRaidPointHistory()
         end
-
+        local player
         for _,history in ipairs(pointList) do
             local reason = history:Reason() or 0
             local value = tostring(history:Value())
@@ -365,9 +365,9 @@ local function tableDataFeeder()
             local profiles = history:Profiles()
             if #profiles == 1 then
                 local currentProfile = profiles[1]
-                local player = UTILS.ColorCodeText(currentProfile:Name(), UTILS.GetClassColor(currentProfile:Class()).hex)
+                player = UTILS.ColorCodeText(currentProfile:Name(), UTILS.GetClassColor(currentProfile:Class()).hex)
             else
-                local player = UTILS.ColorCodeText(CLM.L["Multiple"], "FFD100")
+                player = UTILS.ColorCodeText(CLM.L["Multiple"], "FFD100")
             end
 
             local row = {cols = {

--- a/Modules/GUI/UnifiedGUI_History.lua
+++ b/Modules/GUI/UnifiedGUI_History.lua
@@ -342,8 +342,6 @@ local function tableDataFeeder()
             pointList = roster:GetRaidPointHistory()
         end
 
-        local multiple = UTILS.ColorCodeText(CLM.L["Multiple"], "FFD100")
-
         for _,history in ipairs(pointList) do
             local reason = history:Reason() or 0
             local value = tostring(history:Value())
@@ -364,6 +362,14 @@ local function tableDataFeeder()
 
             value = value .. " " .. suffix
 
+            local profiles = history:Profiles()
+            if #profiles == 1 then
+                local currentProfile = profiles[1]
+                local player = UTILS.ColorCodeText(currentProfile:Name(), UTILS.GetClassColor(currentProfile:Class()).hex)
+            else
+                local player = UTILS.ColorCodeText(CLM.L["Multiple"], "FFD100")
+            end
+
             local row = {cols = {
                 {value = ""},
                 {value = CONSTANTS.POINT_CHANGE_REASONS.ALL[reason] or ""},
@@ -371,7 +377,7 @@ local function tableDataFeeder()
                     color = ((isEPGP and history:Spent()) and colorTurquoise)
                 },
                 {value = date(CLM.L["%Y/%m/%d %H:%M:%S (%A)"], history:Timestamp())},
-                {value = multiple},
+                {value = player},
                 {value = false},
                 {value = history}
             }}


### PR DESCRIPTION
In history tab, directly display player name instead of "multiple" if only one player is affected.